### PR TITLE
Try to force Dependency Bot to update Creek dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,4 @@ updates:
       - creek-github-packages
     schedule:
       interval: weekly
+    versioning-strategy: increase


### PR DESCRIPTION
Even though Dependency Bot has detected a newer version it doesn't raise a PR to update. Instead it logs:

```
updater | INFO <job_358449353> Requirements to unlock update_not_possible
updater | INFO <job_358449353> Requirements update strategy 
updater | INFO <job_358449353> No update possible for org.creek:creek-test-hamcrest 0.+
```

Which... doesn't shed much light on the situation ;)