### PR TITLE
Fix dependency bot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,4 +21,3 @@ updates:
       - creek-github-packages
     schedule:
       interval: weekly
-    versioning-strategy: increase


### PR DESCRIPTION
Looks like it doesn't like `versioning-strategy: increase` for Gradle... which leaves us screwed...
