### PR TITLE
Flip API

### DIFF
--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/Model.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/Model.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.api;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.creekservice.api.base.annotation.VisibleForTesting;
+import org.creekservice.api.system.test.extension.model.Expectation;
+import org.creekservice.api.system.test.extension.model.ExpectationHandler;
+import org.creekservice.api.system.test.extension.model.ExpectationRef;
+import org.creekservice.api.system.test.extension.model.Input;
+import org.creekservice.api.system.test.extension.model.InputHandler;
+import org.creekservice.api.system.test.extension.model.InputRef;
+import org.creekservice.api.system.test.extension.model.ModelContainer;
+import org.creekservice.api.system.test.extension.model.ModelType;
+
+public final class Model implements ModelContainer {
+
+    private final long threadId;
+    private final Map<Class<?>, ModelType<?>> types = new HashMap<>();
+    private final Map<Class<? extends Input>, InputHandler<?>> inputHandlers = new HashMap<>();
+    private final Map<Class<? extends Expectation>, ExpectationHandler<?>> expectationHandlers =
+            new HashMap<>();
+
+    public Model() {
+        this(Thread.currentThread().getId());
+    }
+
+    @VisibleForTesting
+    Model(final long threadId) {
+        this.threadId = threadId;
+    }
+
+    @Override
+    public <T extends InputRef & ExpectationRef> NameBuilder addRef(final Class<T> type) {
+        return addType(type, ModelType::ref, ModelType::ref);
+    }
+
+    @Override
+    public <T extends InputRef> NameBuilder addInputRef(final Class<T> type) {
+        return addType(type, ModelType::inputRef, ModelType::inputRef);
+    }
+
+    @Override
+    public <T extends ExpectationRef> NameBuilder addExpectationRef(final Class<T> type) {
+        return addType(type, ModelType::expectationRef, ModelType::expectationRef);
+    }
+
+    @Override
+    public <T extends Input> NameBuilder addInput(
+            final Class<T> type, final InputHandler<T> handler) {
+        requireNonNull(handler, "handler");
+        final NameBuilder builder = addType(type, ModelType::input, ModelType::input);
+        inputHandlers.put(type, handler);
+        return builder;
+    }
+
+    @Override
+    public <T extends Expectation> NameBuilder addExpectation(
+            final Class<T> type, final ExpectationHandler<T> handler) {
+        requireNonNull(handler, "handler");
+        final NameBuilder builder = addType(type, ModelType::expectation, ModelType::expectation);
+        expectationHandlers.put(type, handler);
+        return builder;
+    }
+
+    @Override
+    public boolean hasType(final Class<?> type) {
+        throwIfNotOnCorrectThread();
+
+        return types.containsKey(requireNonNull(type, "type"));
+    }
+
+    public List<ModelType<?>> modelTypes() {
+        throwIfNotOnCorrectThread();
+
+        return List.copyOf(types.values());
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <T extends Input> Optional<InputHandler<T>> inputHandler(final Class<T> type) {
+        throwIfNotOnCorrectThread();
+
+        return Optional.ofNullable((InputHandler) inputHandlers.get(requireNonNull(type, "type")));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <T extends Expectation> Optional<ExpectationHandler<T>> expectationHandler(
+            final Class<T> type) {
+        throwIfNotOnCorrectThread();
+
+        return Optional.ofNullable(
+                (ExpectationHandler) expectationHandlers.get(requireNonNull(type, "type")));
+    }
+
+    private <T> NameBuilder addType(
+            final Class<T> type,
+            final Function<Class<T>, ModelType<T>> stdNaming,
+            final BiFunction<Class<T>, String, ModelType<T>> customNaming) {
+        throwIfNotOnCorrectThread();
+
+        types.compute(
+                requireNonNull(type, "type"),
+                (k, existing) -> {
+                    if (existing != null) {
+                        throw new IllegalArgumentException("duplicate type: " + type.getName());
+                    }
+                    return stdNaming.apply(type);
+                });
+
+        return name -> types.put(type, customNaming.apply(type, name));
+    }
+
+    private void throwIfNotOnCorrectThread() {
+        if (Thread.currentThread().getId() != threadId) {
+            throw new ConcurrentModificationException("Class is not thread safe");
+        }
+    }
+}

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/SystemTest.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/SystemTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.api;
+
+import static java.util.Objects.requireNonNull;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Collection;
+import org.creekservice.api.base.annotation.VisibleForTesting;
+import org.creekservice.api.system.test.extension.CreekSystemTest;
+import org.creekservice.api.system.test.extension.CreekTestExtension;
+import org.creekservice.api.system.test.extension.model.ModelContainer;
+import org.creekservice.api.system.test.extension.model.ModelType;
+
+public final class SystemTest implements CreekSystemTest {
+
+    private final Model model;
+
+    public SystemTest(final Collection<? extends CreekTestExtension> extensions) {
+        this(extensions, new Model());
+    }
+
+    @VisibleForTesting
+    SystemTest(final Collection<? extends CreekTestExtension> extensions, final Model model) {
+        this.model = requireNonNull(model, "model");
+        extensions.forEach(ext -> ext.initialize(this));
+    }
+
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intentional exposure")
+    @Override
+    public ModelContainer model() {
+        return model;
+    }
+
+    public Collection<ModelType<?>> modelTypes() {
+        return model.modelTypes();
+    }
+}

--- a/executor/src/test/java/module-info.test
+++ b/executor/src/test/java/module-info.test
@@ -12,3 +12,6 @@
 
 --add-opens
   java.base/java.util=org.junitpioneer
+
+--add-exports
+  creek.system.test.executor/org.creekservice.internal.system.test.executor.api=guava.testlib

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/ModelTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/ModelTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.ParameterizedTest.INDEX_PLACEHOLDER;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.testing.NullPointerTester;
+import java.util.Arrays;
+import java.util.ConcurrentModificationException;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.creekservice.api.system.test.extension.model.Expectation;
+import org.creekservice.api.system.test.extension.model.ExpectationHandler;
+import org.creekservice.api.system.test.extension.model.ExpectationRef;
+import org.creekservice.api.system.test.extension.model.Input;
+import org.creekservice.api.system.test.extension.model.InputHandler;
+import org.creekservice.api.system.test.extension.model.InputRef;
+import org.creekservice.api.system.test.extension.model.ModelType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ModelTest {
+
+    private Model model;
+    @Mock private InputHandler<TestInput> inputHandler;
+    @Mock private ExpectationHandler<TestExpectation> expectationHandler;
+
+    @BeforeEach
+    void setUp() {
+        model = new Model();
+    }
+
+    @Test
+    void shouldThrowNPEs() {
+        final NullPointerTester tester =
+                new NullPointerTester().setDefault(Class.class, DerivedFromEverything.class);
+        tester.testAllPublicConstructors(Model.class);
+        tester.testAllPublicStaticMethods(Model.class);
+        tester.testAllPublicInstanceMethods(model);
+    }
+
+    @Test
+    void shouldStartEmpty() {
+        assertThat(model.modelTypes(), is(empty()));
+        assertThat(model.hasType(TestRef.class), is(false));
+        assertThat(model.inputHandler(TestInput.class), is(Optional.empty()));
+        assertThat(model.expectationHandler(TestExpectation.class), is(Optional.empty()));
+    }
+
+    @Test
+    void shouldAddRef() {
+        // When:
+        model.addRef(TestRef.class);
+
+        // Then:
+        assertThat(model.modelTypes(), contains(ModelType.ref(TestRef.class)));
+        assertThat(model.hasType(TestRef.class), is(true));
+    }
+
+    @Test
+    void shouldAddNamedRef() {
+        // When:
+        model.addRef(TestRef.class).withName("Bob");
+
+        // Then:
+        assertThat(model.modelTypes(), contains(ModelType.ref(TestRef.class, "Bob")));
+    }
+
+    @Test
+    void shouldAddInputRef() {
+        // When:
+        model.addInputRef(TestInputRef.class);
+
+        // Then:
+        assertThat(model.modelTypes(), contains(ModelType.inputRef(TestInputRef.class)));
+        assertThat(model.hasType(TestInputRef.class), is(true));
+    }
+
+    @Test
+    void shouldAddNamedInputRef() {
+        // When:
+        model.addInputRef(TestInputRef.class).withName("Bob");
+
+        // Then:
+        assertThat(model.modelTypes(), contains(ModelType.inputRef(TestInputRef.class, "Bob")));
+    }
+
+    @Test
+    void shouldAddExpectationRef() {
+        // When:
+        model.addExpectationRef(TestExpectationRef.class);
+
+        // Then:
+        assertThat(
+                model.modelTypes(), contains(ModelType.expectationRef(TestExpectationRef.class)));
+        assertThat(model.hasType(TestExpectationRef.class), is(true));
+    }
+
+    @Test
+    void shouldAddNamedExpectationRef() {
+        // When:
+        model.addExpectationRef(TestExpectationRef.class).withName("Bob");
+
+        // Then:
+        assertThat(
+                model.modelTypes(),
+                contains(ModelType.expectationRef(TestExpectationRef.class, "Bob")));
+    }
+
+    @Test
+    void shouldAddInput() {
+        // When:
+        model.addInput(TestInput.class, inputHandler);
+
+        // Then:
+        assertThat(model.modelTypes(), contains(ModelType.input(TestInput.class)));
+        assertThat(model.hasType(TestInput.class), is(true));
+        assertThat(model.inputHandler(TestInput.class), is(Optional.of(inputHandler)));
+    }
+
+    @Test
+    void shouldAddNamedInput() {
+        // When:
+        model.addInput(TestInput.class, inputHandler).withName("Bob");
+
+        // Then:
+        assertThat(model.modelTypes(), contains(ModelType.input(TestInput.class, "Bob")));
+    }
+
+    @Test
+    void shouldAddExpectation() {
+        // When:
+        model.addExpectation(TestExpectation.class, expectationHandler);
+
+        // Then:
+        assertThat(model.modelTypes(), contains(ModelType.expectation(TestExpectation.class)));
+        assertThat(model.hasType(TestExpectation.class), is(true));
+        assertThat(
+                model.expectationHandler(TestExpectation.class),
+                is(Optional.of(expectationHandler)));
+    }
+
+    @Test
+    void shouldAddNamedExpectation() {
+        // When:
+        model.addExpectation(TestExpectation.class, expectationHandler).withName("Bob");
+
+        // Then:
+        assertThat(
+                model.modelTypes(), contains(ModelType.expectation(TestExpectation.class, "Bob")));
+    }
+
+    @Test
+    void shouldThrowOnDuplicateAdd() {
+        // Given:
+        model.addInputRef(TestRef.class);
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> model.addExpectationRef(TestRef.class));
+
+        // Then:
+        assertThat(e.getMessage(), is("duplicate type: " + TestRef.class.getName()));
+    }
+
+    @ParameterizedTest(name = "[" + INDEX_PLACEHOLDER + "] {0}")
+    @MethodSource("publicMethods")
+    void shouldThrowIfWrongThread(final String ignored, final Consumer<Model> method) {
+        // Given:
+        model = new Model(Thread.currentThread().getId() + 1);
+
+        // Then:
+        assertThrows(ConcurrentModificationException.class, () -> method.accept(model));
+    }
+
+    @Test
+    void shouldHaveThreadingTestForEachPublicMethod() {
+        final int publicMethodCount = publicMethodCount();
+        final int testedMethodCount = (int) publicMethods().count();
+        assertThat(testedMethodCount, is(publicMethodCount));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Stream<Arguments> publicMethods() {
+        return Stream.of(
+                Arguments.of("modelTypes", (Consumer<Model>) Model::modelTypes),
+                Arguments.of("modelTypes", (Consumer<Model>) m -> m.hasType(TestRef.class)),
+                Arguments.of("modelTypes", (Consumer<Model>) m -> m.addRef(TestRef.class)),
+                Arguments.of(
+                        "modelTypes", (Consumer<Model>) m -> m.addInputRef(TestInputRef.class)),
+                Arguments.of(
+                        "modelTypes",
+                        (Consumer<Model>) m -> m.addExpectationRef(TestExpectationRef.class)),
+                Arguments.of(
+                        "modelTypes",
+                        (Consumer<Model>)
+                                m -> m.addInput(TestInput.class, mock(InputHandler.class))),
+                Arguments.of(
+                        "modelTypes",
+                        (Consumer<Model>)
+                                m ->
+                                        m.addExpectation(
+                                                TestExpectation.class,
+                                                mock(ExpectationHandler.class))),
+                Arguments.of("modelTypes", (Consumer<Model>) m -> m.inputHandler(TestInput.class)),
+                Arguments.of(
+                        "modelTypes",
+                        (Consumer<Model>) m -> m.expectationHandler(TestExpectation.class)));
+    }
+
+    private int publicMethodCount() {
+        return (int)
+                Arrays.stream(Model.class.getMethods())
+                        .filter(m -> !m.getDeclaringClass().equals(Object.class))
+                        .count();
+    }
+
+    private static final class TestRef implements InputRef, ExpectationRef {
+        @Override
+        public String id() {
+            return null;
+        }
+    }
+
+    private static final class TestInputRef implements InputRef {
+        @Override
+        public String id() {
+            return null;
+        }
+    }
+
+    private static final class TestExpectationRef implements ExpectationRef {
+        @Override
+        public String id() {
+            return null;
+        }
+    }
+
+    private static final class TestInput implements Input {}
+
+    private static final class TestExpectation implements Expectation {}
+
+    private static final class DerivedFromEverything
+            implements InputRef, ExpectationRef, Input, Expectation {
+        @Override
+        public String id() {
+            return null;
+        }
+    }
+}

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/SystemTestTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/SystemTestTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.creekservice.api.system.test.extension.CreekSystemTest;
+import org.creekservice.api.system.test.extension.CreekTestExtension;
+import org.creekservice.api.system.test.extension.model.InputRef;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SystemTestTest {
+
+    @Mock private CreekTestExtension ext1;
+    @Mock private CreekTestExtension ext2;
+    @Mock private Model model;
+    private SystemTest api;
+    @Captor private ArgumentCaptor<SystemTest> apiCapture;
+    private final Class<? extends InputRef> refType = mock(InputRef.class).getClass();
+
+    @Test
+    void shouldExposeModel() {
+        // Given:
+        api = new SystemTest(List.of(ext1, ext2), model);
+
+        // Then:
+        assertThat(api.model(), is(sameInstance(model)));
+    }
+
+    @Test
+    void shouldExposeModelToExtensions() {
+        // When:
+        api = new SystemTest(List.of(ext1, ext2), model);
+
+        // Then:
+        verify(ext1).initialize(apiCapture.capture());
+        assertThat(apiCapture.getValue().model(), is(sameInstance(model)));
+
+        verify(ext2).initialize(apiCapture.capture());
+        assertThat(apiCapture.getValue().model(), is(sameInstance(model)));
+    }
+
+    @Test
+    void shouldGetModelTypes() {
+        // Given:
+        doAnswer(
+                        inv -> {
+                            final CreekSystemTest api = inv.getArgument(0);
+                            api.model().addInputRef(refType);
+                            return null;
+                        })
+                .when(ext1)
+                .initialize(any());
+
+        doAnswer(
+                        inv -> {
+                            final CreekSystemTest api = inv.getArgument(0);
+                            api.model().addInputRef(refType);
+                            return null;
+                        })
+                .when(ext2)
+                .initialize(any());
+
+        // When:
+        api = new SystemTest(List.of(ext1, ext2), model);
+
+        // Then:
+        verify(model, times(2)).addInputRef(refType);
+    }
+}

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/CreekSystemTest.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/CreekSystemTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.extension;
+
+
+import org.creekservice.api.system.test.extension.model.ModelContainer;
+
+/** API to the system tests exposed to extensions */
+public interface CreekSystemTest {
+
+    ModelContainer model();
+}

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/CreekSystemTest.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/CreekSystemTest.java
@@ -22,5 +22,12 @@ import org.creekservice.api.system.test.extension.model.ModelContainer;
 /** API to the system tests exposed to extensions */
 public interface CreekSystemTest {
 
+    /**
+     * Information about the data model of the system tests.
+     *
+     * <p>This is the model used when deserializing system tests.
+     *
+     * @return the model.
+     */
     ModelContainer model();
 }

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/CreekTestExtension.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/CreekTestExtension.java
@@ -16,10 +16,6 @@
 
 package org.creekservice.api.system.test.extension;
 
-
-import java.util.Set;
-import org.creekservice.api.system.test.extension.model.ModelType;
-
 /**
  * Base type for system test extensions to Creek.
  *
@@ -38,6 +34,6 @@ public interface CreekTestExtension {
     /** @return the extension name. */
     String name();
 
-    /** @return the set of system test model subtypes the extension exposes. */
-    Set<ModelType<?>> modelTypes();
+    /** Called to allow the extension to do its thing. */
+    void initialize(CreekSystemTest systemTest);
 }

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/model/ExpectationHandler.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/model/ExpectationHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.extension.model;
+
+
+import java.util.Collection;
+
+/**
+ * Handler of {@link Expectation}'s.
+ *
+ * <p>Extensions implement this interface to handle processing of their custom {@link Expectation}
+ * types.
+ *
+ * @param <T> the expectation type.
+ */
+public interface ExpectationHandler<T extends Expectation> {
+
+    /**
+     * Prepare expectations.
+     *
+     * <p>Called before inputs to the current test case are processed, to allow the verifiers to
+     * know the initial state of the system.
+     *
+     * @param expectations the expectations to prepare to verify.
+     * @return the verifier that will be called to verify the supplied {@code expectations}.
+     */
+    Verifier prepare(Collection<T> expectations);
+
+    interface Verifier {
+
+        /**
+         * Verify the expectations.
+         *
+         * @throws AssertionError on unmet expectations. Will include details of <i>which</i>
+         *     expectation is not met.
+         */
+        void verify();
+    }
+}

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/model/InputHandler.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/model/InputHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.extension.model;
+
+/**
+ * Handler of {@link Input}'s.
+ *
+ * <p>Extensions implement this interface to handle processing of their custom {@link Input} types.
+ *
+ * @param <T> the input type.
+ */
+public interface InputHandler<T extends Input> {
+
+    /**
+     * Process the supplied {@code input}.
+     *
+     * <p>The implementation will attempt to send or act upon the supplied {@code input} data. The
+     * implementation can choose whether this is done synchronously or asynchronously. {@link
+     * #flush()} will block until any outstanding asynchronous operations have completed.
+     *
+     * @param input the input to process.
+     */
+    void process(T input);
+
+    /**
+     * Block until any asynchronous operations started during previous calls to {@link #process}
+     * have completed.
+     *
+     * <p>The implementation will ensure the call does not block indefinitely.
+     */
+    default void flush() {}
+}

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/model/ModelCollection.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/model/ModelCollection.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.extension.model;
+
+public interface ModelCollection {
+
+    /**
+     * Checks if the model contains the supplied extension type.
+     *
+     * @param type the extension type to check.
+     * @return {@code true} if the extension type is known, {@code false} otherwise.
+     */
+    boolean hasType(Class<?> type);
+}

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/model/ModelContainer.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/model/ModelContainer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.extension.model;
+
+public interface ModelContainer extends ModelCollection {
+
+    /**
+     * Register a generic {@link Ref} model extension.
+     *
+     * @param type the model extension.
+     * @param <T> the model extension.
+     * @return a builder that can be used to customize the model.
+     */
+    <T extends InputRef & ExpectationRef> NameBuilder addRef(Class<T> type);
+
+    /**
+     * Register an {@link InputRef} model extension.
+     *
+     * @param type the model extension.
+     * @param <T> the model extension.
+     * @return a builder that can be used to customize the model.
+     */
+    <T extends InputRef> NameBuilder addInputRef(Class<T> type);
+
+    /**
+     * Register an {@link ExpectationRef} model extension.
+     *
+     * @param type the model extension.
+     * @param <T> the model extension.
+     * @return a builder that can be used to customize the model.
+     */
+    <T extends ExpectationRef> NameBuilder addExpectationRef(Class<T> type);
+
+    /**
+     * Register an {@link Input} model extension and its handler.
+     *
+     * @param type the model extension.
+     * @param handler the handler called to handle instances of this type.
+     * @param <T> the model extension.
+     * @return a builder that can be used to customize the model.
+     */
+    <T extends Input> NameBuilder addInput(Class<T> type, InputHandler<T> handler);
+
+    /**
+     * Register an {@link Expectation} model extension and its handler.
+     *
+     * @param type the model extension.
+     * @param handler the handler called to handle instances of this type.
+     * @param <T> the model extension.
+     * @return a builder that can be used to customize the model.
+     */
+    <T extends Expectation> NameBuilder addExpectation(
+            Class<T> type, ExpectationHandler<T> handler);
+
+    interface NameBuilder {
+        /**
+         * Sets a custom name for the model.
+         *
+         * <p>This name if the name used within the YAML files in the {@code type} property to
+         * inform the deserializer to deserialize the object as your custom type.
+         *
+         * <p>The default name of the subtype will be derived from the {@code type} name. See {@code
+         * SubTypeNaming.subTypeName()} in {@code creek-base-schema} module for more info details.
+         *
+         * @param name the custom name, as used in the YAML files.
+         */
+        void withName(String name);
+    }
+}

--- a/model/src/test/java/org/creekservice/api/system/test/model/TestCaseTest.java
+++ b/model/src/test/java/org/creekservice/api/system/test/model/TestCaseTest.java
@@ -108,8 +108,8 @@ class TestCaseTest {
     @Test
     void shouldSetTestSuiteOnBuild() {
         // Given:
-        final List<Input> inputs = List.of(this.input);
-        final List<Expectation> expectations = List.of(this.expectation);
+        final List<Input> inputs = List.of(input);
+        final List<Expectation> expectations = List.of(expectation);
         final TestCase.Builder builder = testCase(inputs, expectations, def(inputs, expectations));
 
         // When:
@@ -117,6 +117,38 @@ class TestCaseTest {
 
         // Then:
         assertThat(testCase.suite(), is(sameInstance(suite)));
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    void shouldReturnImmutableInputs() {
+        // Given:
+        final List<Input> inputs =
+                testCase(
+                                List.of(input),
+                                List.of(expectation),
+                                def(List.of(input), List.of(expectation)))
+                        .build(suite)
+                        .inputs();
+
+        // Then:
+        assertThrows(UnsupportedOperationException.class, () -> inputs.remove(0));
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    void shouldReturnImmutableExpectations() {
+        // Given:
+        final List<Expectation> expectations =
+                testCase(
+                                List.of(input),
+                                List.of(expectation),
+                                def(List.of(input), List.of(expectation)))
+                        .build(suite)
+                        .expectations();
+
+        // Then:
+        assertThrows(UnsupportedOperationException.class, () -> expectations.remove(0));
     }
 
     private TestCaseDef def(

--- a/test-extension/src/main/java/org/creekservice/api/system/test/test/extension/TestExpectation.java
+++ b/test-extension/src/main/java/org/creekservice/api/system/test/test/extension/TestExpectation.java
@@ -45,4 +45,9 @@ public final class TestExpectation implements Expectation {
     public int hashCode() {
         return Objects.hash(output);
     }
+
+    @Override
+    public String toString() {
+        return "TestExpectation{" + "output='" + output + '\'' + '}';
+    }
 }

--- a/test-extension/src/main/java/org/creekservice/api/system/test/test/extension/TestExtension.java
+++ b/test-extension/src/main/java/org/creekservice/api/system/test/test/extension/TestExtension.java
@@ -17,9 +17,10 @@
 package org.creekservice.api.system.test.test.extension;
 
 
-import java.util.Set;
+import java.util.Collection;
+import org.creekservice.api.system.test.extension.CreekSystemTest;
 import org.creekservice.api.system.test.extension.CreekTestExtension;
-import org.creekservice.api.system.test.extension.model.ModelType;
+import org.creekservice.api.system.test.extension.model.ExpectationHandler.Verifier;
 
 public final class TestExtension implements CreekTestExtension {
 
@@ -29,7 +30,11 @@ public final class TestExtension implements CreekTestExtension {
     }
 
     @Override
-    public Set<ModelType<?>> modelTypes() {
-        return Set.of(ModelType.expectation(TestExpectation.class));
+    public void initialize(final CreekSystemTest systemTest) {
+        systemTest.model().addExpectation(TestExpectation.class, this::prepareExpectation);
+    }
+
+    private Verifier prepareExpectation(final Collection<TestExpectation> expectations) {
+        return () -> System.out.println("Verifying expectations: " + expectations);
     }
 }


### PR DESCRIPTION
Flip the API so that it's the system tests providing an API to the extensions rather than the extensions exposing an API to the system tests.  This gives more flexibility and power to extension authors and is easier to enhance.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended