### PR TITLE
Add Component Discovery and wire in stub services under test

### DIFF
--- a/executor/build.gradle.kts
+++ b/executor/build.gradle.kts
@@ -26,6 +26,7 @@ val spotBugsVersion : String by extra
 
 dependencies {
     implementation("org.creekservice:creek-base-type:$creekBaseVersion")
+    implementation("org.creekservice:creek-platform-metadata:$creekBaseVersion")
     implementation(project(":extension"))
     implementation(project(":parser"))
     implementation("com.github.spotbugs:spotbugs-annotations:$spotBugsVersion")
@@ -35,6 +36,7 @@ dependencies {
     runtimeOnly("org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion")
 
     testImplementation(project(":test-extension"))
+    testImplementation(project(":test-services"))
 }
 
 application {
@@ -45,4 +47,5 @@ application {
 tasks.test {
     dependsOn("installDist")
     dependsOn(":test-extension:jar")
+    dependsOn(":test-services:jar")
 }

--- a/executor/src/main/java/module-info.java
+++ b/executor/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 module creek.system.test.executor {
     requires creek.base.type;
+    requires creek.platform.metadata;
     requires creek.system.test.extension;
     requires creek.system.test.parser;
     requires info.picocli;
@@ -11,4 +12,6 @@ module creek.system.test.executor {
 
     opens org.creekservice.internal.system.test.executor.cli to
             info.picocli;
+
+    uses org.creekservice.api.platform.metadata.ComponentDescriptor;
 }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/LocalServiceInstances.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/LocalServiceInstances.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.api;
+
+
+import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+import java.util.List;
+import org.creekservice.api.base.annotation.VisibleForTesting;
+import org.creekservice.api.system.test.extension.service.ServiceContainer;
+import org.creekservice.api.system.test.extension.service.ServiceDefinition;
+import org.creekservice.api.system.test.extension.service.ServiceInstance;
+
+/** A local, docker based, implementation of {@link ServiceContainer}. */
+public final class LocalServiceInstances implements ServiceContainer {
+
+    private final long threadId;
+    private final List<ServiceInstance> instances = new ArrayList<>();
+
+    public LocalServiceInstances() {
+        this(Thread.currentThread().getId());
+    }
+
+    @VisibleForTesting
+    LocalServiceInstances(final long threadId) {
+        this.threadId = threadId;
+    }
+
+    @Override
+    public ServiceInstance start(final ServiceDefinition def) {
+        throwIfNotOnCorrectThread();
+        final Instance instance = new Instance(def);
+        instances.add(instance);
+        return instance;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public Iterator<ServiceInstance> iterator() {
+        throwIfNotOnCorrectThread();
+        return instances.iterator();
+    }
+
+    private void throwIfNotOnCorrectThread() {
+        if (Thread.currentThread().getId() != threadId) {
+            throw new ConcurrentModificationException("Class is not thread safe");
+        }
+    }
+
+    private static final class Instance implements ServiceInstance {
+        Instance(final ServiceDefinition def) {}
+
+        @Override
+        public void stop() {}
+    }
+}

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/ServiceDefinitions.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/ServiceDefinitions.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.api;
+
+import static java.lang.System.lineSeparator;
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.creekservice.api.base.annotation.VisibleForTesting;
+import org.creekservice.api.base.type.CodeLocation;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.creekservice.api.platform.metadata.ServiceDescriptor;
+import org.creekservice.api.system.test.extension.service.ServiceDefinition;
+import org.creekservice.api.system.test.extension.service.ServiceDefinitionCollection;
+
+public final class ServiceDefinitions implements ServiceDefinitionCollection {
+
+    private final long threadId;
+    private final Map<String, ServiceDefinition> services;
+
+    public ServiceDefinitions(final Collection<? extends ComponentDescriptor> components) {
+        this(components, Thread.currentThread().getId());
+    }
+
+    @VisibleForTesting
+    ServiceDefinitions(
+            final Collection<? extends ComponentDescriptor> components, final long threadId) {
+        this.threadId = threadId;
+        this.services = toDefinitions(components);
+    }
+
+    @Override
+    public ServiceDefinition get(final String serviceName) {
+        throwIfNotOnCorrectThread();
+        final ServiceDefinition def = services.get(serviceName);
+        if (def == null) {
+            throw new UnknownServiceDefinitionException(serviceName, services.keySet());
+        }
+        return def;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public Iterator<ServiceDefinition> iterator() {
+        throwIfNotOnCorrectThread();
+        return services.values().iterator();
+    }
+
+    private static Map<String, ServiceDefinition> toDefinitions(
+            final Collection<? extends ComponentDescriptor> components) {
+        return components.stream()
+                .filter(ServiceDescriptor.class::isInstance)
+                .map(ServiceDescriptor.class::cast)
+                .map(ServiceDefinitions::toDefinition)
+                .collect(
+                        Collectors.toUnmodifiableMap(
+                                ServiceDefinition::name, Function.identity(), throwOnNameClash()));
+    }
+
+    private static ServiceDefinition toDefinition(final ServiceDescriptor descriptor) {
+        return new ServiceDescriptorBasedDefinition(descriptor);
+    }
+
+    private static BinaryOperator<ServiceDefinition> throwOnNameClash() {
+        return (def0, def1) -> {
+            throw new ServiceDescriptorNameClashException(
+                    (ServiceDescriptorBasedDefinition) def0,
+                    (ServiceDescriptorBasedDefinition) def1);
+        };
+    }
+
+    private void throwIfNotOnCorrectThread() {
+        if (Thread.currentThread().getId() != threadId) {
+            throw new ConcurrentModificationException("Class is not thread safe");
+        }
+    }
+
+    private static final class ServiceDescriptorNameClashException
+            extends IllegalArgumentException {
+
+        ServiceDescriptorNameClashException(
+                final ServiceDescriptorBasedDefinition def0,
+                final ServiceDescriptorBasedDefinition def1) {
+            super(
+                    "Two or more ServiceDescriptors where found with the same name. Names must be unique."
+                            + lineSeparator()
+                            + "service_name: "
+                            + def0.name()
+                            + lineSeparator()
+                            + "descriptor_locations: ["
+                            + lineSeparator()
+                            + CodeLocation.codeLocation(def0.descriptor)
+                            + lineSeparator()
+                            + CodeLocation.codeLocation(def1.descriptor)
+                            + lineSeparator()
+                            + "]");
+        }
+    }
+
+    private static final class UnknownServiceDefinitionException extends IllegalArgumentException {
+        UnknownServiceDefinitionException(
+                final String serviceName, final Set<String> knownServices) {
+            super(
+                    "Unknown service: "
+                            + serviceName
+                            + ". Known services are: "
+                            + sorted(knownServices));
+        }
+
+        private static List<String> sorted(final Collection<String> serviceNames) {
+            final List<String> sorted = new ArrayList<>(serviceNames);
+            sorted.sort(Comparator.naturalOrder());
+            return sorted;
+        }
+    }
+
+    private static final class ServiceDescriptorBasedDefinition implements ServiceDefinition {
+
+        private final ServiceDescriptor descriptor;
+
+        ServiceDescriptorBasedDefinition(final ServiceDescriptor descriptor) {
+            this.descriptor = requireNonNull(descriptor, "descriptor");
+        }
+
+        @Override
+        public String name() {
+            return descriptor.name();
+        }
+    }
+}

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/SystemTest.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/SystemTest.java
@@ -21,25 +21,31 @@ import static java.util.Objects.requireNonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collection;
 import org.creekservice.api.base.annotation.VisibleForTesting;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.api.system.test.extension.CreekSystemTest;
 import org.creekservice.api.system.test.extension.CreekTestExtension;
 
 public final class SystemTest implements CreekSystemTest {
 
     private final Model model;
-    private final Tests tests;
+    private final TestSuiteEnv testEnv;
+    private final ServiceDefinitions services;
 
-    public SystemTest(final Collection<? extends CreekTestExtension> extensions) {
-        this(extensions, new Model(), new Tests());
+    public SystemTest(
+            final Collection<? extends CreekTestExtension> extensions,
+            final Collection<? extends ComponentDescriptor> components) {
+        this(extensions, new Model(), new TestSuiteEnv(), new ServiceDefinitions(components));
     }
 
     @VisibleForTesting
     SystemTest(
             final Collection<? extends CreekTestExtension> extensions,
             final Model model,
-            final Tests tests) {
+            final TestSuiteEnv testEnv,
+            final ServiceDefinitions services) {
         this.model = requireNonNull(model, "model");
-        this.tests = requireNonNull(tests, "test");
+        this.testEnv = requireNonNull(testEnv, "testEnv");
+        this.services = requireNonNull(services, "services");
         extensions.forEach(ext -> ext.initialize(this));
     }
 
@@ -51,7 +57,13 @@ public final class SystemTest implements CreekSystemTest {
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intentional exposure")
     @Override
-    public Tests test() {
-        return tests;
+    public TestSuiteEnv testSuite() {
+        return testEnv;
+    }
+
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intentional exposure")
+    @Override
+    public ServiceDefinitions services() {
+        return services;
     }
 }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/TestSuiteEnv.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/TestSuiteEnv.java
@@ -20,25 +20,32 @@ import static java.util.Objects.requireNonNull;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.creekservice.api.base.annotation.VisibleForTesting;
-import org.creekservice.api.system.test.extension.test.SystemTestPackage;
-import org.creekservice.api.system.test.extension.test.TestListenerContainer;
+import org.creekservice.api.system.test.extension.test.TestSuiteEnvironment;
 
-public final class Tests implements SystemTestPackage {
+public final class TestSuiteEnv implements TestSuiteEnvironment {
 
     private final TestListeners listeners;
+    private final LocalServiceInstances services;
 
-    public Tests() {
-        this(new TestListeners());
+    public TestSuiteEnv() {
+        this(new TestListeners(), new LocalServiceInstances());
     }
 
     @VisibleForTesting
-    Tests(final TestListeners listeners) {
+    TestSuiteEnv(final TestListeners listeners, final LocalServiceInstances services) {
         this.listeners = requireNonNull(listeners, "listeners");
+        this.services = requireNonNull(services, "services");
     }
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intentional exposure")
     @Override
-    public TestListenerContainer listener() {
+    public TestListeners listener() {
         return listeners;
+    }
+
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intentional exposure")
+    @Override
+    public LocalServiceInstances services() {
+        return services;
     }
 }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/components/ComponentDescriptors.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/components/ComponentDescriptors.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.components;
+
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+
+public final class ComponentDescriptors {
+
+    private ComponentDescriptors() {}
+
+    /** Instantiate any extensions available at runtime. */
+    public static List<ComponentDescriptor> load() {
+        return ServiceLoader.load(ComponentDescriptor.class).stream()
+                .map(ServiceLoader.Provider::get)
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/TestCaseExecutor.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/TestCaseExecutor.java
@@ -42,9 +42,7 @@ public final class TestCaseExecutor {
         listeners.forEach(listener -> listener.beforeTest(testCase));
     }
 
-    private void runTest(final TestCase testCase) {
-        // Coming soon...
-    }
+    private void runTest(final TestCase testCase) {}
 
     private void afterTest(final TestCase testCase) {
         listeners.forEachReverse(listener -> listener.afterTest(testCase));

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/ServicesUnderTestLifecycleListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/ServicesUnderTestLifecycleListener.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.execution.listener;
+
+import static java.util.Objects.requireNonNull;
+import static org.creekservice.api.base.type.Iterators.reverseIterator;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.creekservice.api.system.test.extension.model.CreekTestSuite;
+import org.creekservice.api.system.test.extension.service.ServiceDefinition;
+import org.creekservice.api.system.test.extension.service.ServiceInstance;
+import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
+import org.creekservice.internal.system.test.executor.api.SystemTest;
+
+/**
+ * A test lifecycle listener that is responsible for starting and stopping the services under test.
+ *
+ * <p>Before each test suite is executed the listener will start an instance of each service listed
+ * under the test suites {@code services} property, in the order they are defined.
+ *
+ * <p>After each test suite, the listener will stop the instances it started, in reverse order.
+ */
+public final class ServicesUnderTestLifecycleListener implements TestLifecycleListener {
+
+    private final SystemTest api;
+    private final List<ServiceInstance> started = new ArrayList<>();
+
+    public ServicesUnderTestLifecycleListener(final SystemTest api) {
+        this.api = requireNonNull(api, "api");
+    }
+
+    @Override
+    public void beforeSuite(final CreekTestSuite suite) {
+        started.clear();
+        suite.services().stream().map(this::startServicesUnderTest).forEachOrdered(started::add);
+    }
+
+    @Override
+    public void afterSuite(final CreekTestSuite suite) {
+        reverseIterator(started).forEachRemaining(ServiceInstance::stop);
+    }
+
+    private ServiceInstance startServicesUnderTest(final String serviceName) {
+        final ServiceDefinition def = api.services().get(serviceName);
+        return api.testSuite().services().start(def);
+    }
+}

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/StopAllServicesTestLifecycleListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/StopAllServicesTestLifecycleListener.java
@@ -19,24 +19,26 @@ package org.creekservice.internal.system.test.executor.execution.listener;
 import static java.util.Objects.requireNonNull;
 
 import org.creekservice.api.system.test.extension.model.CreekTestSuite;
+import org.creekservice.api.system.test.extension.service.ServiceInstance;
 import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
 import org.creekservice.internal.system.test.executor.api.SystemTest;
 
-public final class CreekTestLifecycleListener implements TestLifecycleListener {
+/**
+ * A test lifecycle listener that stops any services left running at the end of a test suite.
+ *
+ * <p>Generally, services should be stopped by the class/extension that started them. This is here
+ * to ensure all services are stopped after the suite has run.
+ */
+public final class StopAllServicesTestLifecycleListener implements TestLifecycleListener {
 
     private final SystemTest api;
 
-    public CreekTestLifecycleListener(final SystemTest api) {
+    public StopAllServicesTestLifecycleListener(final SystemTest api) {
         this.api = requireNonNull(api, "api");
     }
 
     @Override
-    public void beforeSuite(final CreekTestSuite suite) {
-        // Coming soon...
-    }
-
-    @Override
     public void afterSuite(final CreekTestSuite suite) {
-        // Coming soon...
+        api.testSuite().services().forEach(ServiceInstance::stop);
     }
 }

--- a/executor/src/test/java/module-info.test
+++ b/executor/src/test/java/module-info.test
@@ -1,8 +1,8 @@
 --add-modules
-  org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity
+  org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,creek.system.test.test.services
 
 --add-reads
-  creek.system.test.executor=org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity
+  creek.system.test.executor=org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,creek.system.test.test.services
 
 --add-opens
   org.junitpioneer/org.junitpioneer.jupiter=org.junit.platform.commons

--- a/executor/src/test/java/org/creekservice/api/system/test/executor/SystemTestExecutorFunctionalTest.java
+++ b/executor/src/test/java/org/creekservice/api/system/test/executor/SystemTestExecutorFunctionalTest.java
@@ -57,6 +57,9 @@ class SystemTestExecutorFunctionalTest {
     private static final Path TEST_EXT_LIB_DIR =
             TestPaths.moduleRoot("test-extension").resolve("build/libs").toAbsolutePath();
 
+    private static final Path TEST_SERVICES_LIB_DIR =
+            TestPaths.moduleRoot("test-services").resolve("build/libs").toAbsolutePath();
+
     private static final String SEPARATOR = System.getProperty("path.separator");
 
     private static final Pattern VERSION_PATTERN =
@@ -295,7 +298,8 @@ class SystemTestExecutorFunctionalTest {
     }
 
     private int runExecutor(final String[] cmdArgs) {
-        final String modulePath = LIB_DIR + SEPARATOR + TEST_EXT_LIB_DIR;
+        final String modulePath =
+                LIB_DIR + SEPARATOR + TEST_EXT_LIB_DIR + SEPARATOR + TEST_SERVICES_LIB_DIR;
 
         final String[] javaArgs = {
             "--module-path",
@@ -349,7 +353,7 @@ class SystemTestExecutorFunctionalTest {
 
     private String suiteContent(final int numberTestCases) {
         final String header =
-                "---\n" + "name: suite name\n" + "services:\n" + "  - service_a\n" + "tests:\n";
+                "---\n" + "name: suite name\n" + "services:\n" + "  - test-service\n" + "tests:\n";
 
         final String cases =
                 IntStream.range(0, numberTestCases)

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/LocalServiceInstancesTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/LocalServiceInstancesTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.ParameterizedTest.INDEX_PLACEHOLDER;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.creekservice.api.system.test.extension.service.ServiceDefinition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class LocalServiceInstancesTest {
+
+    private LocalServiceInstances instances;
+
+    @SuppressWarnings("unused")
+    @ParameterizedTest(name = "[" + INDEX_PLACEHOLDER + "] {0}")
+    @MethodSource("publicMethods")
+    void shouldThrowIfWrongThread(
+            final String ignored, final Consumer<LocalServiceInstances> method) {
+        // Given:
+        instances = new LocalServiceInstances(Thread.currentThread().getId() + 1);
+
+        // Then:
+        assertThrows(ConcurrentModificationException.class, () -> method.accept(instances));
+    }
+
+    @Test
+    void shouldHaveThreadingTestForEachPublicMethod() {
+        final List<String> publicMethodNames = publicMethodNames();
+        final int testedMethodCount = (int) publicMethods().count();
+        assertThat(
+                "Public methods:\n" + String.join(System.lineSeparator(), publicMethodNames),
+                testedMethodCount,
+                is(publicMethodNames.size()));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Stream<Arguments> publicMethods() {
+        return Stream.of(
+                Arguments.of(
+                        "spliterator",
+                        (Consumer<LocalServiceInstances>) LocalServiceInstances::spliterator),
+                Arguments.of(
+                        "iterator",
+                        (Consumer<LocalServiceInstances>) LocalServiceInstances::iterator),
+                Arguments.of(
+                        "start",
+                        (Consumer<LocalServiceInstances>)
+                                si -> si.start(mock(ServiceDefinition.class))),
+                Arguments.of(
+                        "forEach",
+                        (Consumer<LocalServiceInstances>) si -> si.forEach(mock(Consumer.class))));
+    }
+
+    private List<String> publicMethodNames() {
+        return Arrays.stream(LocalServiceInstances.class.getMethods())
+                .filter(m -> !m.getDeclaringClass().equals(Object.class))
+                .map(Method::toGenericString)
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/ModelTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/ModelTest.java
@@ -196,6 +196,7 @@ class ModelTest {
         assertThat(e.getMessage(), is("duplicate type: " + TestRef.class.getName()));
     }
 
+    @SuppressWarnings("unused")
     @ParameterizedTest(name = "[" + INDEX_PLACEHOLDER + "] {0}")
     @MethodSource("publicMethods")
     void shouldThrowIfWrongThread(final String ignored, final Consumer<Model> method) {

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/ServiceDefinitionsTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/ServiceDefinitionsTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.ParameterizedTest.INDEX_PLACEHOLDER;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.creekservice.api.platform.metadata.AggregateDescriptor;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.creekservice.api.platform.metadata.ServiceDescriptor;
+import org.creekservice.api.system.test.extension.service.ServiceDefinition;
+import org.creekservice.api.system.test.test.services.TestServiceDescriptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ServiceDefinitionsTest {
+
+    @Mock private ServiceDescriptor serviceDescriptor0;
+    private final ServiceDescriptor serviceDescriptor1 = new TestServiceDescriptor();
+    private ServiceDefinitions services;
+
+    @BeforeEach
+    void setUp() {
+        when(serviceDescriptor0.name()).thenReturn("service-0");
+
+        services = new ServiceDefinitions(List.of(serviceDescriptor0, serviceDescriptor1));
+    }
+
+    @Test
+    void shouldIgnoreNonServiceDescriptors() {
+        // When:
+        services =
+                new ServiceDefinitions(
+                        List.of(
+                                serviceDescriptor0,
+                                mock(ComponentDescriptor.class),
+                                mock(AggregateDescriptor.class),
+                                serviceDescriptor1));
+
+        // Then:
+        final List<ServiceDefinition> defs = new ArrayList<>(2);
+        services.forEach(defs::add);
+        assertThat(defs, hasSize(2));
+    }
+
+    @Test
+    void shouldThrowOnServiceNameClashWithAMessageIncludeJarLocations() {
+        // Given:
+        when(serviceDescriptor0.name()).thenReturn(serviceDescriptor1.name());
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                new ServiceDefinitions(
+                                        List.of(serviceDescriptor0, serviceDescriptor1)));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                startsWith(
+                        "Two or more ServiceDescriptors where found with the same name. Names must be unique."));
+        assertThat(e.getMessage(), containsString("service_name: test-service"));
+        assertThat(
+                e.getMessage(),
+                matchesPattern(
+                        Pattern.compile(
+                                ".*file:/.*creek-platform-metadata-\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?\\.jar.*",
+                                Pattern.DOTALL)));
+        assertThat(
+                e.getMessage(),
+                matchesPattern(
+                        Pattern.compile(
+                                ".*file:/.*creek-system-test-test-services-\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?\\.jar.*",
+                                Pattern.DOTALL)));
+    }
+
+    @Test
+    void shouldGetByServiceName() {
+        assertThat(services.get("service-0").name(), is("service-0"));
+        assertThat(
+                services.get(TestServiceDescriptor.SERVICE_NAME).name(),
+                is(TestServiceDescriptor.SERVICE_NAME));
+    }
+
+    @Test
+    void shouldThrowFromGetOnUnknownServiceName() {
+        // When:
+        final Exception e =
+                assertThrows(IllegalArgumentException.class, () -> services.get("unknown-service"));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is(
+                        "Unknown service: unknown-service. Known services are: [service-0, test-service]"));
+    }
+
+    @SuppressWarnings("unused")
+    @ParameterizedTest(name = "[" + INDEX_PLACEHOLDER + "] {0}")
+    @MethodSource("publicMethods")
+    void shouldThrowIfWrongThread(final String ignored, final Consumer<ServiceDefinitions> method) {
+        // Given:
+        services = new ServiceDefinitions(List.of(), Thread.currentThread().getId() + 1);
+
+        // Then:
+        assertThrows(ConcurrentModificationException.class, () -> method.accept(services));
+    }
+
+    @Test
+    void shouldHaveThreadingTestForEachPublicMethod() {
+        final List<String> publicMethodNames = publicMethodNames();
+        final int testedMethodCount = (int) publicMethods().count();
+        assertThat(
+                "Public methods:\n" + String.join(System.lineSeparator(), publicMethodNames),
+                testedMethodCount,
+                is(publicMethodNames.size()));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Stream<Arguments> publicMethods() {
+        return Stream.of(
+                Arguments.of("get", (Consumer<ServiceDefinitions>) s -> s.get("name")),
+                Arguments.of(
+                        "iterator", (Consumer<ServiceDefinitions>) ServiceDefinitions::iterator),
+                Arguments.of("spliterator", (Consumer<ServiceDefinitions>) Iterable::spliterator),
+                Arguments.of(
+                        "forEach",
+                        (Consumer<ServiceDefinitions>) s -> s.forEach(mock(Consumer.class))));
+    }
+
+    private List<String> publicMethodNames() {
+        return Arrays.stream(ServiceDefinitions.class.getMethods())
+                .filter(m -> !m.getDeclaringClass().equals(Object.class))
+                .map(Method::toGenericString)
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/SystemTestTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/SystemTestTest.java
@@ -19,16 +19,11 @@ package org.creekservice.internal.system.test.executor.api;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
-import org.creekservice.api.system.test.extension.CreekSystemTest;
 import org.creekservice.api.system.test.extension.CreekTestExtension;
-import org.creekservice.api.system.test.extension.model.InputRef;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -42,24 +37,25 @@ class SystemTestTest {
     @Mock private CreekTestExtension ext1;
     @Mock private CreekTestExtension ext2;
     @Mock private Model model;
-    @Mock private Tests tests;
+    @Mock private TestSuiteEnv testEnv;
+    @Mock private ServiceDefinitions services;
     private SystemTest api;
     @Captor private ArgumentCaptor<SystemTest> apiCapture;
-    private final Class<? extends InputRef> refType = mock(InputRef.class).getClass();
+
+    @BeforeEach
+    void setUp() {
+        api = new SystemTest(List.of(), model, testEnv, services);
+    }
 
     @Test
     void shouldExposeModel() {
-        // Given:
-        api = new SystemTest(List.of(ext1, ext2), model, tests);
-
-        // Then:
         assertThat(api.model(), is(sameInstance(model)));
     }
 
     @Test
     void shouldExposeModelToExtensions() {
         // When:
-        api = new SystemTest(List.of(ext1, ext2), model, tests);
+        api = new SystemTest(List.of(ext1, ext2), model, testEnv, services);
 
         // Then:
         verify(ext1).initialize(apiCapture.capture());
@@ -70,52 +66,38 @@ class SystemTestTest {
     }
 
     @Test
-    void shouldExposeTests() {
-        // Given:
-        api = new SystemTest(List.of(ext1, ext2), model, tests);
-
-        // Then:
-        assertThat(api.test(), is(sameInstance(tests)));
+    void shouldExposeTestEnv() {
+        assertThat(api.testSuite(), is(sameInstance(testEnv)));
     }
 
     @Test
-    void shouldExposeTestsToExtensions() {
+    void shouldExposeTestEnvToExtensions() {
         // When:
-        api = new SystemTest(List.of(ext1, ext2), model, tests);
+        api = new SystemTest(List.of(ext1, ext2), model, testEnv, services);
 
         // Then:
         verify(ext1).initialize(apiCapture.capture());
-        assertThat(apiCapture.getValue().test(), is(sameInstance(tests)));
+        assertThat(apiCapture.getValue().testSuite(), is(sameInstance(testEnv)));
 
         verify(ext2).initialize(apiCapture.capture());
-        assertThat(apiCapture.getValue().test(), is(sameInstance(tests)));
+        assertThat(apiCapture.getValue().testSuite(), is(sameInstance(testEnv)));
     }
 
     @Test
-    void shouldGetModelTypes() {
-        // Given:
-        doAnswer(
-                        inv -> {
-                            final CreekSystemTest api = inv.getArgument(0);
-                            api.model().addInputRef(refType);
-                            return null;
-                        })
-                .when(ext1)
-                .initialize(any());
+    void shouldExposeServiceRegistry() {
+        assertThat(api.services(), is(sameInstance(services)));
+    }
 
-        doAnswer(
-                        inv -> {
-                            final CreekSystemTest api = inv.getArgument(0);
-                            api.model().addInputRef(refType);
-                            return null;
-                        })
-                .when(ext2)
-                .initialize(any());
-
+    @Test
+    void shouldExposeServiceRegistryToExtensions() {
         // When:
-        api = new SystemTest(List.of(ext1, ext2), model, tests);
+        api = new SystemTest(List.of(ext1, ext2), model, testEnv, services);
 
         // Then:
-        verify(model, times(2)).addInputRef(refType);
+        verify(ext1).initialize(apiCapture.capture());
+        assertThat(apiCapture.getValue().services(), is(sameInstance(services)));
+
+        verify(ext2).initialize(apiCapture.capture());
+        assertThat(apiCapture.getValue().services(), is(sameInstance(services)));
     }
 }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/TestEnvTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/TestEnvTest.java
@@ -20,23 +20,31 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class TestsTest {
+class TestEnvTest {
 
     @Mock private TestListeners listeners;
-    private Tests tests;
+    @Mock private LocalServiceInstances services;
+    private TestSuiteEnv testEnv;
+
+    @BeforeEach
+    void setUp() {
+        testEnv = new TestSuiteEnv(listeners, services);
+    }
 
     @Test
     void shouldExposeListeners() {
-        // Given:
-        tests = new Tests(listeners);
+        assertThat(testEnv.listener(), is(sameInstance(listeners)));
+    }
 
-        // Then:
-        assertThat(tests.listener(), is(sameInstance(listeners)));
+    @Test
+    void shouldExposeServices() {
+        assertThat(testEnv.services(), is(sameInstance(services)));
     }
 }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/components/ComponentDescriptorsTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/components/ComponentDescriptorsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.components;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
+
+import java.util.List;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.creekservice.api.system.test.test.services.TestServiceDescriptor;
+import org.junit.jupiter.api.Test;
+
+class ComponentDescriptorsTest {
+
+    @Test
+    void shouldLoadTestDescriptors() {
+        // When:
+        final List<ComponentDescriptor> result = ComponentDescriptors.load();
+
+        // Then:
+        assertThat(result, containsInAnyOrder(instanceOf(TestServiceDescriptor.class)));
+    }
+}

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/listener/ServicesUnderTestLifecycleListenerTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/listener/ServicesUnderTestLifecycleListenerTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.execution.listener;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.creekservice.api.system.test.extension.model.CreekTestSuite;
+import org.creekservice.api.system.test.extension.service.ServiceDefinition;
+import org.creekservice.api.system.test.extension.service.ServiceInstance;
+import org.creekservice.internal.system.test.executor.api.SystemTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ServicesUnderTestLifecycleListenerTest {
+
+    @Mock(answer = RETURNS_DEEP_STUBS)
+    private SystemTest api;
+
+    @Mock private CreekTestSuite suite;
+    private ServicesUnderTestLifecycleListener listener;
+    private final Map<String, ServiceDefinition> defs = new HashMap<>();
+    private final Map<String, ServiceInstance> instances = new HashMap<>();
+
+    @BeforeEach
+    void setUp() {
+        defs.clear();
+        instances.clear();
+
+        listener = new ServicesUnderTestLifecycleListener(api);
+    }
+
+    @Test
+    void shouldStartServicesBeforeSuiteInOrder() {
+        // Given:
+        givenSuiteHasServices("a", "b", "c");
+
+        // When:
+        listener.beforeSuite(suite);
+
+        // Then:
+        final InOrder inOrder = inOrder(api.services(), api.testSuite().services());
+        inOrder.verify(api.services()).get("a");
+        inOrder.verify(api.testSuite().services()).start(defs.get("a"));
+        inOrder.verify(api.services()).get("b");
+        inOrder.verify(api.testSuite().services()).start(defs.get("b"));
+        inOrder.verify(api.services()).get("c");
+        inOrder.verify(api.testSuite().services()).start(defs.get("c"));
+    }
+
+    @Test
+    void shouldStopServicesAfterSuiteInReverseOrder() {
+        // Given:
+        givenSuiteHasServices("a", "b", "c");
+        listener.beforeSuite(suite);
+
+        // When:
+        listener.afterSuite(suite);
+
+        // Then:
+        final InOrder inOrder = inOrder(instances.values().toArray());
+        inOrder.verify(instances.get("c:0")).stop();
+        inOrder.verify(instances.get("b:0")).stop();
+        inOrder.verify(instances.get("a:0")).stop();
+    }
+
+    @Test
+    void shouldSupportMultipleServicesWithSameName() {
+        // Given:
+        givenSuiteHasServices("a", "a");
+
+        // When:
+        listener.beforeSuite(suite);
+        listener.afterSuite(suite);
+
+        // Then:
+        verify(api.testSuite().services(), times(2)).start(defs.get("a"));
+        verify(instances.get("a:1")).stop();
+        verify(instances.get("a:0")).stop();
+    }
+
+    @Test
+    void shouldThrowOnUnknownService() {
+        // Given:
+        when(suite.services()).thenReturn(List.of("misspelled-service"));
+        when(api.services().get(any())).thenThrow(new RuntimeException("unknown service"));
+
+        // When:
+        final Exception e = assertThrows(RuntimeException.class, () -> listener.beforeSuite(suite));
+
+        // Then:
+        assertThat(e.getMessage(), is("unknown service"));
+    }
+
+    @Test
+    void shouldStopStartedServicesOnAfterSuiteEvenIfBeforeSuiteThrew() {
+        // Given:
+        givenSuiteHasServices("a", "bad-service", "c");
+        when(api.services().get("bad-service")).thenThrow(new RuntimeException("unknown service"));
+
+        assertThrows(Exception.class, () -> listener.beforeSuite(suite));
+
+        // When:
+        listener.afterSuite(suite);
+
+        // Then:
+        verify(instances.get("a:0")).stop();
+        verify(instances.get("bad-service:0"), never()).stop();
+        verify(instances.get("c:0"), never()).stop();
+    }
+
+    private void givenSuiteHasServices(final String... serviceNames) {
+        when(suite.services()).thenReturn(List.of(serviceNames));
+
+        Arrays.stream(serviceNames)
+                .collect(Collectors.groupingBy(Function.identity()))
+                .values()
+                .forEach(this::setupServiceMocks);
+    }
+
+    private void setupServiceMocks(final List<String> serviceNames) {
+        final String serviceName = serviceNames.get(0);
+        final ServiceDefinition def = setUpDefMock(serviceName);
+
+        ServiceInstance first = null;
+        final ServiceInstance[] others = new ServiceInstance[serviceNames.size() - 1];
+
+        for (int i = 0; i != serviceNames.size(); ++i) {
+            final String instanceName = serviceName + ":" + i;
+            final ServiceInstance instance = mock(ServiceInstance.class, instanceName);
+            instances.put(instanceName, instance);
+
+            if (i == 0) {
+                first = instance;
+            } else {
+                others[i - 1] = instance;
+            }
+        }
+
+        when(api.testSuite().services().start(def)).thenReturn(first, others);
+    }
+
+    private ServiceDefinition setUpDefMock(final String serviceName) {
+        return defs.computeIfAbsent(
+                serviceName,
+                name -> {
+                    final ServiceDefinition def = mock(ServiceDefinition.class, serviceName);
+                    when(api.services().get(name)).thenReturn(def);
+                    return def;
+                });
+    }
+}

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/listener/StopAllServicesTestLifecycleListenerTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/listener/StopAllServicesTestLifecycleListenerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.execution.listener;
+
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+import org.creekservice.api.system.test.extension.service.ServiceInstance;
+import org.creekservice.internal.system.test.executor.api.SystemTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StopAllServicesTestLifecycleListenerTest {
+
+    @Mock(answer = RETURNS_DEEP_STUBS)
+    private SystemTest api;
+
+    private StopAllServicesTestLifecycleListener listener;
+    @Mock private ServiceInstance service;
+    @Captor private ArgumentCaptor<Consumer<? super ServiceInstance>> actionCaptor;
+
+    @BeforeEach
+    void setUp() {
+        listener = new StopAllServicesTestLifecycleListener(api);
+    }
+
+    @Test
+    void shouldStopAllServices() {
+        // When:
+        listener.afterSuite(null);
+
+        // Then:
+        verify(api.testSuite().services()).forEach(actionCaptor.capture());
+        actionCaptor.getValue().accept(service);
+        verify(service).stop();
+    }
+}

--- a/extension/src/main/java/module-info.java
+++ b/extension/src/main/java/module-info.java
@@ -2,6 +2,7 @@ module creek.system.test.extension {
     exports org.creekservice.api.system.test.extension;
     exports org.creekservice.api.system.test.extension.model;
     exports org.creekservice.api.system.test.extension.test;
+    exports org.creekservice.api.system.test.extension.service;
 
     uses org.creekservice.api.system.test.extension.CreekTestExtension;
 }

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/CreekSystemTest.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/CreekSystemTest.java
@@ -18,7 +18,8 @@ package org.creekservice.api.system.test.extension;
 
 
 import org.creekservice.api.system.test.extension.model.ModelContainer;
-import org.creekservice.api.system.test.extension.test.SystemTestPackage;
+import org.creekservice.api.system.test.extension.service.ServiceDefinitionCollection;
+import org.creekservice.api.system.test.extension.test.TestSuiteEnvironment;
 
 /** API to the system tests exposed to extensions */
 public interface CreekSystemTest {
@@ -33,9 +34,18 @@ public interface CreekSystemTest {
     ModelContainer model();
 
     /**
-     * The test being executed.
+     * The test suite being executed.
      *
      * @return the test container.
      */
-    SystemTestPackage test();
+    TestSuiteEnvironment testSuite();
+
+    /**
+     * The services known to Creek.
+     *
+     * <p>These are the services discovered on the class or module path.
+     *
+     * @return a collection of services.
+     */
+    ServiceDefinitionCollection services();
 }

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceCollection.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceCollection.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.extension.service;
+
+/** A collection of service instances */
+public interface ServiceCollection extends Iterable<ServiceInstance> {}

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceContainer.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceContainer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.extension.service;
+
+/** A container of services */
+public interface ServiceContainer extends ServiceCollection {
+
+    /**
+     * Start an instance of a service.
+     *
+     * @param def the def of the service to start.
+     */
+    ServiceInstance start(ServiceDefinition def);
+}

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceDefinition.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceDefinition.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.extension.service;
+
+/** Information required by Creek System Test to start a service */
+public interface ServiceDefinition {
+    /**
+     * The name of the service.
+     *
+     * <p>This name must be unique within the system.
+     *
+     * @return the name of the service.
+     */
+    String name();
+}

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceDefinitionCollection.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceDefinitionCollection.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.extension.service;
+
+public interface ServiceDefinitionCollection extends Iterable<ServiceDefinition> {
+    ServiceDefinition get(String serviceName);
+}

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceInstance.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceInstance.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.extension.service;
+
+/** An instance of a {@link ServiceDefinition} */
+public interface ServiceInstance {
+
+    /** Stop the instance. No-op if already stopped. */
+    void stop();
+}

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/test/TestSuiteEnvironment.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/test/TestSuiteEnvironment.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.extension.test;
+
+
+import org.creekservice.api.system.test.extension.service.ServiceContainer;
+
+/** The environment in which test suites execute. */
+public interface TestSuiteEnvironment {
+
+    /**
+     * Test listeners.
+     *
+     * <p>Listeners are invoked on test lifecycle events.
+     *
+     * @return test listeners
+     */
+    TestListenerContainer listener();
+
+    /**
+     * Services within the test environment.
+     *
+     * @return service container.
+     */
+    ServiceContainer services();
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,5 +6,6 @@ include(
     "model",
     "parser",
     "test-extension",
-    "test-service"
+    "test-service",
+    "test-services"
 )

--- a/test-services/README.md
+++ b/test-services/README.md
@@ -1,0 +1,4 @@
+# Test Services
+
+A module that defines the metadata for the [Test Service](../test-service).
+

--- a/test-services/build.gradle.kts
+++ b/test-services/build.gradle.kts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    `java-library`
+}
+
+val creekBaseVersion : String by extra
+
+dependencies {
+    implementation("org.creekservice:creek-platform-metadata:$creekBaseVersion")
+}

--- a/test-services/src/main/java/module-info.java
+++ b/test-services/src/main/java/module-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.creekservice.api.system.test.test.services.TestServiceDescriptor;
+
+module creek.system.test.test.services {
+    requires transitive creek.platform.metadata;
+
+    exports org.creekservice.api.system.test.test.services;
+
+    provides ComponentDescriptor with
+            TestServiceDescriptor;
+}

--- a/test-services/src/main/java/org/creekservice/api/system/test/test/services/TestServiceDescriptor.java
+++ b/test-services/src/main/java/org/creekservice/api/system/test/test/services/TestServiceDescriptor.java
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-package org.creekservice.api.system.test.extension.test;
+package org.creekservice.api.system.test.test.services;
 
-/** The API exposed to extensions for viewing and interacting with test packages. */
-public interface SystemTestPackage {
 
-    /**
-     * Test listeners.
-     *
-     * <p>Listeners are invoked on test lifecycle events.
-     *
-     * @return test listeners
-     */
-    TestListenerContainer listener();
+import org.creekservice.api.platform.metadata.ServiceDescriptor;
+
+public final class TestServiceDescriptor implements ServiceDescriptor {
+    public static final String SERVICE_NAME = "test-service";
+
+    @Override
+    public String name() {
+        return SERVICE_NAME;
+    }
 }


### PR DESCRIPTION
Part of https://github.com/creek-service/creek-system-test/issues/36

- Add functionality to discover service descriptors at start up.
- Use this to populate a `ServiceDefinitions` type.
- Add `services()` to the test environment to track service instances started in the current test suite run.
- Initial local stub impl of `ServiceContainer` that does nothing
- Flesh out `ServicesUnderTestLifecycleListener` to start and stop the services under test
- Add `StopAllServicesTestLifecycleListener` to ensure all services are stopped at the end of the suite.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended