### PR TITLE
Start services in docker containers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,7 @@ subprojects {
     extra.apply {
         set("creekBaseVersion", "0.2.0-SNAPSHOT")
         set("creekTestVersion", "0.2.0-SNAPSHOT")
+        set("testContainersVersion", "1.17.2")  // https://mvnrepository.com/artifact/org.testcontainers/testcontainers
         set("spotBugsVersion", "4.7.0")         // https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-annotations
         set("jacksonVersion", "2.13.3")         // https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations
         set("picocliVersion", "4.6.3")          // https://mvnrepository.com/artifact/info.picocli/picocli

--- a/executor/build.gradle.kts
+++ b/executor/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 }
 
 val creekBaseVersion : String by extra
+val testContainersVersion : String by extra
 val picocliVersion : String by extra
 val log4jVersion : String by extra
 val spotBugsVersion : String by extra
@@ -29,8 +30,9 @@ dependencies {
     implementation("org.creekservice:creek-platform-metadata:$creekBaseVersion")
     implementation(project(":extension"))
     implementation(project(":parser"))
-    implementation("com.github.spotbugs:spotbugs-annotations:$spotBugsVersion")
 
+    implementation("com.github.spotbugs:spotbugs-annotations:$spotBugsVersion")
+    implementation("org.testcontainers:testcontainers:$testContainersVersion")
     implementation("info.picocli:picocli:$picocliVersion")
     implementation("org.apache.logging.log4j:log4j-api:$log4jVersion")
     runtimeOnly("org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion")
@@ -48,4 +50,5 @@ tasks.test {
     dependsOn("installDist")
     dependsOn(":test-extension:jar")
     dependsOn(":test-services:jar")
+    dependsOn(":test-service:buildAppImage")
 }

--- a/executor/src/main/java/module-info.java
+++ b/executor/src/main/java/module-info.java
@@ -4,9 +4,11 @@ module creek.system.test.executor {
     requires creek.system.test.extension;
     requires creek.system.test.parser;
     requires info.picocli;
+    requires org.slf4j;
     requires org.apache.logging.log4j;
     requires java.management;
     requires com.github.spotbugs.annotations;
+    requires testcontainers;
 
     exports org.creekservice.api.system.test.executor;
 

--- a/executor/src/main/java/org/creekservice/api/system/test/executor/SystemTestExecutor.java
+++ b/executor/src/main/java/org/creekservice/api/system/test/executor/SystemTestExecutor.java
@@ -23,8 +23,6 @@ import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.creekservice.api.base.type.JarVersion;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.api.system.test.extension.CreekTestExtension;
@@ -41,11 +39,13 @@ import org.creekservice.internal.system.test.executor.execution.listener.StopAll
 import org.creekservice.internal.system.test.executor.observation.TestPackageParserObserver;
 import org.creekservice.internal.system.test.executor.result.ResultsWriter;
 import org.creekservice.internal.system.test.executor.result.TestExecutionResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Entry point for running system tests */
 public final class SystemTestExecutor {
 
-    private static final Logger LOGGER = LogManager.getLogger(SystemTestExecutor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SystemTestExecutor.class);
 
     private SystemTestExecutor() {}
 
@@ -64,7 +64,7 @@ public final class SystemTestExecutor {
 
             System.exit(success ? 0 : 1);
         } catch (final Exception e) {
-            LOGGER.fatal(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             System.exit(2);
         }
     }
@@ -105,11 +105,11 @@ public final class SystemTestExecutor {
 
     private static void echo(final ExecutorOptions options) {
         LOGGER.info(
-                "SystemTestExecutor: "
-                        + JarVersion.jarVersion(SystemTestExecutor.class).orElse("unknown"));
+                "SystemTestExecutor: {}",
+                JarVersion.jarVersion(SystemTestExecutor.class).orElse("unknown"));
         LOGGER.info(classPath());
         LOGGER.info(modulePath());
-        LOGGER.info(options);
+        LOGGER.info("{}", options);
     }
 
     private static String classPath() {

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/LocalServiceInstances.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/LocalServiceInstances.java
@@ -16,21 +16,41 @@
 
 package org.creekservice.internal.system.test.executor.api;
 
+import static java.lang.System.lineSeparator;
+import static java.util.Objects.requireNonNull;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.system.test.extension.service.ServiceContainer;
 import org.creekservice.api.system.test.extension.service.ServiceDefinition;
 import org.creekservice.api.system.test.extension.service.ServiceInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
 
 /** A local, docker based, implementation of {@link ServiceContainer}. */
 public final class LocalServiceInstances implements ServiceContainer {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalServiceInstances.class);
+
+    private static final int CONTAINER_START_UP_ATTEMPTS = 3;
+    private static final Duration CONTAINER_START_UP_TIMEOUT = Duration.ofSeconds(90);
+
     private final long threadId;
+    private final Network network = Network.newNetwork();
     private final List<ServiceInstance> instances = new ArrayList<>();
+    private final Map<String, AtomicInteger> names = new HashMap<>();
 
     public LocalServiceInstances() {
         this(Thread.currentThread().getId());
@@ -44,7 +64,9 @@ public final class LocalServiceInstances implements ServiceContainer {
     @Override
     public ServiceInstance start(final ServiceDefinition def) {
         throwIfNotOnCorrectThread();
+
         final Instance instance = new Instance(def);
+        instance.start();
         instances.add(instance);
         return instance;
     }
@@ -56,16 +78,110 @@ public final class LocalServiceInstances implements ServiceContainer {
         return instances.iterator();
     }
 
+    private String instanceName(final String serviceName) {
+        final AtomicInteger counter = names.computeIfAbsent(serviceName, k -> new AtomicInteger());
+        return serviceName + "-" + counter.getAndIncrement();
+    }
+
+    private GenericContainer<?> createContainer(
+            final DockerImageName imageName, final String instanceName) {
+        final GenericContainer<?> container = new GenericContainer<>(imageName);
+
+        return container
+                .withNetwork(network)
+                .withNetworkAliases(instanceName)
+                .withStartupAttempts(CONTAINER_START_UP_ATTEMPTS)
+                .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(instanceName)))
+                .waitingFor(
+                        Wait.forLogMessage(".*lifecycle.*started.*", 1)
+                                .withStartupTimeout(CONTAINER_START_UP_TIMEOUT));
+    }
+
     private void throwIfNotOnCorrectThread() {
         if (Thread.currentThread().getId() != threadId) {
             throw new ConcurrentModificationException("Class is not thread safe");
         }
     }
 
-    private static final class Instance implements ServiceInstance {
-        Instance(final ServiceDefinition def) {}
+    private static DockerImageName dockerImageName(final ServiceDefinition def) {
+        final String fullName = def.dockerImage() + ":latest";
+        return DockerImageName.parse(fullName);
+    }
+
+    @VisibleForTesting
+    final class Instance implements ServiceInstance {
+
+        private final String name;
+        private final DockerImageName image;
+        private final ServiceDefinition def;
+        private final GenericContainer<?> container;
+        private String cachedContainerId;
+
+        Instance(final ServiceDefinition def) {
+            this.def = requireNonNull(def, "def");
+            this.name = instanceName(def.name());
+            this.image = dockerImageName(def);
+            this.container = requireNonNull(createContainer(image, name), "container");
+            this.cachedContainerId = container.getContainerId();
+        }
 
         @Override
-        public void stop() {}
+        public void start() {
+            if (running()) {
+                return;
+            }
+
+            LOGGER.info("Starting {} ({})", name, image);
+
+            try {
+                container.start();
+                cachedContainerId = container.getContainerId();
+
+                LOGGER.info("Started {} ({}) with container-id {}", name, image, cachedContainerId);
+            } catch (final Exception e) {
+                throw new FailedToStartServiceException(def, container, e);
+            }
+        }
+
+        @Override
+        public boolean running() {
+            throwIfNotOnCorrectThread();
+            return container.getContainerId() != null;
+        }
+
+        @Override
+        public void stop() {
+            if (!running()) {
+                return;
+            }
+
+            LOGGER.info("Stopping {} ({}) with container-id {}", name, image, cachedContainerId);
+            container.stop();
+            LOGGER.info("Stopped {} ({})", name, image);
+        }
+
+        String cachedContainerId() {
+            return cachedContainerId;
+        }
+    }
+
+    private static final class FailedToStartServiceException extends RuntimeException {
+        FailedToStartServiceException(
+                final ServiceDefinition def,
+                final GenericContainer<?> container,
+                final Throwable cause) {
+            super(
+                    "Failed to start service: "
+                            + def.name()
+                            + ", image: "
+                            + dockerImageName(def)
+                            + lineSeparator()
+                            + "Cause: "
+                            + cause.getMessage()
+                            + lineSeparator()
+                            + "Logs: "
+                            + container.getLogs(),
+                    cause);
+        }
     }
 }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/ServiceDefinitions.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/ServiceDefinitions.java
@@ -150,5 +150,10 @@ public final class ServiceDefinitions implements ServiceDefinitionCollection {
         public String name() {
             return descriptor.name();
         }
+
+        @Override
+        public String dockerImage() {
+            return descriptor.dockerImage();
+        }
     }
 }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/cli/PicoCliParser.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/cli/PicoCliParser.java
@@ -23,17 +23,17 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.creekservice.api.base.type.JarVersion;
 import org.creekservice.api.system.test.executor.ExecutorOptions;
 import org.creekservice.api.system.test.executor.SystemTestExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
 public final class PicoCliParser {
 
-    private static final Logger LOGGER = LogManager.getLogger(PicoCliParser.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PicoCliParser.class);
 
     private PicoCliParser() {}
 

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/LoggingTestLifecycleListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/LoggingTestLifecycleListener.java
@@ -17,15 +17,16 @@
 package org.creekservice.internal.system.test.executor.execution.listener;
 
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.creekservice.api.system.test.extension.model.CreekTestCase;
 import org.creekservice.api.system.test.extension.model.CreekTestSuite;
 import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class LoggingTestLifecycleListener implements TestLifecycleListener {
 
-    private static final Logger LOGGER = LogManager.getLogger(LoggingTestLifecycleListener.class);
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(LoggingTestLifecycleListener.class);
 
     @Override
     public void beforeSuite(final CreekTestSuite suite) {

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/observation/TestPackageParserObserver.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/observation/TestPackageParserObserver.java
@@ -23,8 +23,8 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.logging.log4j.Logger;
 import org.creekservice.api.system.test.parser.TestPackageParser;
+import org.slf4j.Logger;
 
 public final class TestPackageParserObserver implements TestPackageParser.Observer {
 

--- a/executor/src/test/java/org/creekservice/api/system/test/executor/SystemTestExecutorFunctionalTest.java
+++ b/executor/src/test/java/org/creekservice/api/system/test/executor/SystemTestExecutorFunctionalTest.java
@@ -128,7 +128,7 @@ class SystemTestExecutorFunctionalTest {
     }
 
     @Test
-    void shouldRunFromClassPath() {
+    void shouldEchoClassPath() {
         // Given:
         final String[] javaArgs = {
             "-cp",
@@ -298,15 +298,21 @@ class SystemTestExecutorFunctionalTest {
     }
 
     private int runExecutor(final String[] cmdArgs) {
-        final String modulePath =
-                LIB_DIR + SEPARATOR + TEST_EXT_LIB_DIR + SEPARATOR + TEST_SERVICES_LIB_DIR;
+        // Run from the classpath by default until test containers works from the module path:
+        final String classPath =
+                LIB_DIR
+                        + "/*"
+                        + SEPARATOR
+                        + TEST_EXT_LIB_DIR
+                        + "/*"
+                        + SEPARATOR
+                        + TEST_SERVICES_LIB_DIR
+                        + "/*";
 
         final String[] javaArgs = {
-            "--module-path",
-            modulePath,
-            "--add-modules=creek.system.test.test.extension",
-            "--add-reads=creek.system.test.extension=creek.system.test.test.extension",
-            "--module=creek.system.test.executor/org.creekservice.api.system.test.executor.SystemTestExecutor"
+            "-cp",
+            classPath,
+            org.creekservice.api.system.test.executor.SystemTestExecutor.class.getName()
         };
         return runExecutor(javaArgs, cmdArgs);
     }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/LocalServiceInstancesTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/LocalServiceInstancesTest.java
@@ -17,27 +17,136 @@
 package org.creekservice.internal.system.test.executor.api;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.ParameterizedTest.INDEX_PLACEHOLDER;
+import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.exception.NotFoundException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.ConcurrentModificationException;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.creekservice.api.system.test.extension.service.ServiceDefinition;
+import org.creekservice.api.system.test.extension.service.ServiceInstance;
+import org.creekservice.internal.system.test.executor.api.LocalServiceInstances.Instance;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.testcontainers.DockerClientFactory;
 
+@ExtendWith(MockitoExtension.class)
 class LocalServiceInstancesTest {
 
+    @Mock(strictness = LENIENT)
+    private ServiceDefinition serviceDef;
+
     private LocalServiceInstances instances;
+
+    private final DockerClient dockerClient = DockerClientFactory.lazyClient();
+
+    @BeforeEach
+    void setUp() {
+        instances = new LocalServiceInstances();
+
+        when(serviceDef.name()).thenReturn("test-service");
+        when(serviceDef.dockerImage()).thenReturn("ghcr.io/creekservice/test-service");
+    }
+
+    @Test
+    void shouldStartAndStopServices() {
+        // When:
+        final ServiceInstance instance0 = instances.start(serviceDef);
+        final ServiceInstance instance1 = instances.start(serviceDef);
+
+        // Then:
+        assertThat(instances(instances), contains(instance0, instance1));
+        assertThat(instance0, is(running(true)));
+        assertThat(instance1, is(running(true)));
+
+        // When:
+        instance0.stop();
+
+        // Then:
+        assertThat(instance0, is(running(false)));
+        assertThat(instance1, is(running(true)));
+
+        // When:
+        instance1.stop();
+
+        // Then:
+        assertThat(instances(instances), contains(instance0, instance1));
+        assertThat(instance0, is(running(false)));
+        assertThat(instance1, is(running(false)));
+    }
+
+    @Test
+    void shouldDoNothingOnSubsequentServiceStops() {
+        // Given:
+        final ServiceInstance instance = instances.start(serviceDef);
+        instance.stop();
+        assertThat(instance, is(running(false)));
+
+        // When:
+        instance.stop();
+
+        // Then: no error and nothing has changed:
+        assertThat(instance, is(running(false)));
+    }
+
+    @Test
+    void shouldRestartService() {
+        // Given:
+        final ServiceInstance instance = instances.start(serviceDef);
+        instance.stop();
+        assertThat(instance, is(running(false)));
+
+        // When:
+        instance.start();
+
+        // Then: no error and nothing has changed:
+        assertThat(instance, is(running(true)));
+    }
+
+    @Test
+    void shouldThrowOnServiceStartFailure() {
+        // Given:
+        when(serviceDef.dockerImage()).thenReturn("i-do-not-exist");
+
+        // When:
+        final Exception e = assertThrows(RuntimeException.class, () -> instances.start(serviceDef));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                startsWith("Failed to start service: test-service, image: i-do-not-exist:latest"));
+        assertThat(e.getMessage(), containsString("Cause: Container startup failed"));
+        assertThat("should not track failed instance", instances(instances), is(empty()));
+    }
 
     @SuppressWarnings("unused")
     @ParameterizedTest(name = "[" + INDEX_PLACEHOLDER + "] {0}")
@@ -61,6 +170,91 @@ class LocalServiceInstancesTest {
                 is(publicMethodNames.size()));
     }
 
+    @SuppressWarnings("unused")
+    @ParameterizedTest(name = "[" + INDEX_PLACEHOLDER + "] {0}")
+    @MethodSource("publicInstanceMethods")
+    void shouldThrowIfWrongThreadForInstance(
+            final String ignored, final Consumer<Instance> method) {
+        // Given:
+        final Instance instance = (Instance) instances.start(serviceDef);
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        try {
+            // Then:
+            final Future<?> result = executor.submit(() -> method.accept(instance));
+            final Exception e = assertThrows(ExecutionException.class, result::get);
+            assertThat(e.getCause(), is(instanceOf(ConcurrentModificationException.class)));
+        } finally {
+            instance.stop();
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    void shouldHaveThreadingTestForEachInstancePublicMethod() {
+        final List<String> publicMethodNames = publicInstanceMethodNames();
+        final int testedMethodCount = (int) publicInstanceMethods().count();
+        assertThat(
+                "Public methods:\n" + String.join(System.lineSeparator(), publicMethodNames),
+                testedMethodCount,
+                is(publicMethodNames.size()));
+    }
+
+    private Matcher<ServiceInstance> running(final boolean expectedRunState) {
+        return new TypeSafeDiagnosingMatcher<>() {
+            @Override
+            protected boolean matchesSafely(
+                    final ServiceInstance item, final Description mismatchDescription) {
+                describeTo(mismatchDescription);
+
+                final boolean testContainersRunState = item.running();
+                final boolean testContainersStateMatch = testContainersRunState == expectedRunState;
+                if (!testContainersStateMatch) {
+                    mismatchDescription
+                            .appendText(" but testContainersRunState was ")
+                            .appendValue(testContainersRunState);
+                }
+
+                final boolean dockerContainerRunState = dockerContainerRunState(item);
+                final boolean dockerContainerStateMatch =
+                        dockerContainerRunState == expectedRunState;
+                if (!dockerContainerStateMatch) {
+                    if (!testContainersStateMatch) {
+                        mismatchDescription.appendText(" and ");
+                    }
+
+                    mismatchDescription
+                            .appendText(" but dockerContainerRunState was ")
+                            .appendValue(dockerContainerRunState);
+                }
+                return testContainersStateMatch && dockerContainerStateMatch;
+            }
+
+            @Override
+            public void describeTo(final Description description) {
+                description
+                        .appendText("Docker container with run state ")
+                        .appendValue(expectedRunState);
+            }
+        };
+    }
+
+    private boolean dockerContainerRunState(final ServiceInstance instance) {
+        final String containerId = ((Instance) instance).cachedContainerId();
+        try {
+            return Boolean.TRUE.equals(
+                    dockerClient.inspectContainerCmd(containerId).exec().getState().getRunning());
+        } catch (NotFoundException e) {
+            return false;
+        }
+    }
+
+    private static List<ServiceInstance> instances(final LocalServiceInstances instances) {
+        final List<ServiceInstance> result = new ArrayList<>(2);
+        instances.forEach(result::add);
+        return result;
+    }
+
     @SuppressWarnings("unchecked")
     public static Stream<Arguments> publicMethods() {
         return Stream.of(
@@ -81,6 +275,20 @@ class LocalServiceInstancesTest {
 
     private List<String> publicMethodNames() {
         return Arrays.stream(LocalServiceInstances.class.getMethods())
+                .filter(m -> !m.getDeclaringClass().equals(Object.class))
+                .map(Method::toGenericString)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public static Stream<Arguments> publicInstanceMethods() {
+        return Stream.of(
+                Arguments.of("start", (Consumer<Instance>) Instance::start),
+                Arguments.of("stop", (Consumer<Instance>) Instance::stop),
+                Arguments.of("running", (Consumer<Instance>) Instance::running));
+    }
+
+    private List<String> publicInstanceMethodNames() {
+        return Arrays.stream(Instance.class.getMethods())
                 .filter(m -> !m.getDeclaringClass().equals(Object.class))
                 .map(Method::toGenericString)
                 .collect(Collectors.toUnmodifiableList());

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceDefinition.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceDefinition.java
@@ -26,4 +26,7 @@ public interface ServiceDefinition {
      * @return the name of the service.
      */
     String name();
+
+    /** @return the docker image name, without version info. */
+    String dockerImage();
 }

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceInstance.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceInstance.java
@@ -19,6 +19,12 @@ package org.creekservice.api.system.test.extension.service;
 /** An instance of a {@link ServiceDefinition} */
 public interface ServiceInstance {
 
+    /** Start the instance. No-op if already started. */
+    void start();
+
+    /** @return {@code true} if the instance is running. */
+    boolean running();
+
     /** Stop the instance. No-op if already stopped. */
     void stop();
 }

--- a/test-extension/src/main/resources/META-INF/services/org.creekservice.api.system.test.extension.CreekTestExtension
+++ b/test-extension/src/main/resources/META-INF/services/org.creekservice.api.system.test.extension.CreekTestExtension
@@ -1,0 +1,17 @@
+#
+# Copyright 2022 Creek Contributors (https://github.com/creek-service)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.creekservice.api.system.test.test.extension.TestExtension

--- a/test-service/src/main/java/org/creekservice/internal/system/test/test/service/ServiceMain.java
+++ b/test-service/src/main/java/org/creekservice/internal/system/test/test/service/ServiceMain.java
@@ -28,6 +28,7 @@ public final class ServiceMain {
 
     public static void main(final String... args) {
         doLogging();
+        awaitShutdown();
     }
 
     private static void doLogging() {
@@ -35,5 +36,18 @@ public final class ServiceMain {
         System.err.println("System.err logging");
         LOGGER.info("LOGGER.info logging");
         LOGGER.error("LOGGER.error logging");
+
+        LOGGER.info("some.lifecycle.event=started");
+    }
+
+    @SuppressWarnings({"InfiniteLoopStatement", "BusyWait"})
+    private static void awaitShutdown() {
+        while (true) {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                // meh
+            }
+        }
     }
 }

--- a/test-services/src/main/java/org/creekservice/api/system/test/test/services/TestServiceDescriptor.java
+++ b/test-services/src/main/java/org/creekservice/api/system/test/test/services/TestServiceDescriptor.java
@@ -26,4 +26,9 @@ public final class TestServiceDescriptor implements ServiceDescriptor {
     public String name() {
         return SERVICE_NAME;
     }
+
+    @Override
+    public String dockerImage() {
+        return "ghcr.io/creekservice/" + name();
+    }
 }

--- a/test-services/src/main/resources/META-INF/services/org.creekservice.api.platform.metadata.ComponentDescriptor
+++ b/test-services/src/main/resources/META-INF/services/org.creekservice.api.platform.metadata.ComponentDescriptor
@@ -1,0 +1,17 @@
+#
+# Copyright 2022 Creek Contributors (https://github.com/creek-service)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.creekservice.api.system.test.test.services.TestServiceDescriptor


### PR DESCRIPTION
Part of https://github.com/creek-service/creek-system-test/issues/36

- each instance of service definition has unique name
- introduction of test containers causes issues with running from module path, hence switched functional tests to class path.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended