### PR TITLE
Add service instances before extension `beforeSuite` method is called

### DIFF
--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/SystemTest.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/SystemTest.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.api.system.test.extension.CreekSystemTest;
-import org.creekservice.api.system.test.extension.CreekTestExtension;
 
 public final class SystemTest implements CreekSystemTest {
 
@@ -31,22 +30,15 @@ public final class SystemTest implements CreekSystemTest {
     private final TestSuiteEnv testEnv;
     private final ServiceDefinitions services;
 
-    public SystemTest(
-            final Collection<? extends CreekTestExtension> extensions,
-            final Collection<? extends ComponentDescriptor> components) {
-        this(extensions, new Model(), new TestSuiteEnv(), new ServiceDefinitions(components));
+    public SystemTest(final Collection<? extends ComponentDescriptor> components) {
+        this(new Model(), new TestSuiteEnv(), new ServiceDefinitions(components));
     }
 
     @VisibleForTesting
-    SystemTest(
-            final Collection<? extends CreekTestExtension> extensions,
-            final Model model,
-            final TestSuiteEnv testEnv,
-            final ServiceDefinitions services) {
+    SystemTest(final Model model, final TestSuiteEnv testEnv, final ServiceDefinitions services) {
         this.model = requireNonNull(model, "model");
         this.testEnv = requireNonNull(testEnv, "testEnv");
         this.services = requireNonNull(services, "services");
-        extensions.forEach(ext -> ext.initialize(this));
     }
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intentional exposure")

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/SuiteCleanUpListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/SuiteCleanUpListener.java
@@ -16,35 +16,32 @@
 
 package org.creekservice.internal.system.test.executor.execution.listener;
 
+import static java.util.Objects.requireNonNull;
 
-import org.creekservice.api.system.test.extension.model.CreekTestCase;
 import org.creekservice.api.system.test.extension.model.CreekTestSuite;
+import org.creekservice.api.system.test.extension.service.ServiceInstance;
 import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.creekservice.internal.system.test.executor.api.SystemTest;
 
-public final class LoggingTestLifecycleListener implements TestLifecycleListener {
+/**
+ * A test lifecycle listener that resets theServiceContainer and stops any services left running at
+ * the end of a test suite.
+ */
+public final class SuiteCleanUpListener implements TestLifecycleListener {
 
-    private static final Logger LOGGER =
-            LoggerFactory.getLogger(LoggingTestLifecycleListener.class);
+    private final SystemTest api;
+
+    public SuiteCleanUpListener(final SystemTest api) {
+        this.api = requireNonNull(api, "api");
+    }
 
     @Override
     public void beforeSuite(final CreekTestSuite suite) {
-        LOGGER.info("Starting suite '" + suite.name() + "'");
+        api.testSuite().services().clear();
     }
 
     @Override
     public void afterSuite(final CreekTestSuite suite) {
-        LOGGER.info("Finished suite '" + suite.name() + "'");
-    }
-
-    @Override
-    public void beforeTest(final CreekTestCase test) {
-        LOGGER.info("Starting test '" + test.name() + "'");
-    }
-
-    @Override
-    public void afterTest(final CreekTestCase test) {
-        LOGGER.info("Finished test '" + test.name() + "'");
+        api.testSuite().services().forEach(ServiceInstance::stop);
     }
 }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/observation/LoggingTestLifecycleListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/observation/LoggingTestLifecycleListener.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.observation;
+
+
+import org.creekservice.api.system.test.extension.model.CreekTestCase;
+import org.creekservice.api.system.test.extension.model.CreekTestSuite;
+import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class LoggingTestLifecycleListener implements TestLifecycleListener {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(LoggingTestLifecycleListener.class);
+
+    @Override
+    public void beforeSuite(final CreekTestSuite suite) {
+        LOGGER.info("Starting suite '" + suite.name() + "'");
+    }
+
+    @Override
+    public void afterSuite(final CreekTestSuite suite) {
+        LOGGER.info("Finished suite '" + suite.name() + "'");
+    }
+
+    @Override
+    public void beforeTest(final CreekTestCase test) {
+        LOGGER.info("Starting test '" + test.name() + "'");
+    }
+
+    @Override
+    public void afterTest(final CreekTestCase test) {
+        LOGGER.info("Finished test '" + test.name() + "'");
+    }
+}

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/SystemTestTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/SystemTestTest.java
@@ -19,32 +19,24 @@ package org.creekservice.internal.system.test.executor.api;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.mockito.Mockito.verify;
 
-import java.util.List;
-import org.creekservice.api.system.test.extension.CreekTestExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class SystemTestTest {
 
-    @Mock private CreekTestExtension ext1;
-    @Mock private CreekTestExtension ext2;
     @Mock private Model model;
     @Mock private TestSuiteEnv testEnv;
     @Mock private ServiceDefinitions services;
     private SystemTest api;
-    @Captor private ArgumentCaptor<SystemTest> apiCapture;
 
     @BeforeEach
     void setUp() {
-        api = new SystemTest(List.of(), model, testEnv, services);
+        api = new SystemTest(model, testEnv, services);
     }
 
     @Test
@@ -53,51 +45,12 @@ class SystemTestTest {
     }
 
     @Test
-    void shouldExposeModelToExtensions() {
-        // When:
-        api = new SystemTest(List.of(ext1, ext2), model, testEnv, services);
-
-        // Then:
-        verify(ext1).initialize(apiCapture.capture());
-        assertThat(apiCapture.getValue().model(), is(sameInstance(model)));
-
-        verify(ext2).initialize(apiCapture.capture());
-        assertThat(apiCapture.getValue().model(), is(sameInstance(model)));
-    }
-
-    @Test
     void shouldExposeTestEnv() {
         assertThat(api.testSuite(), is(sameInstance(testEnv)));
     }
 
     @Test
-    void shouldExposeTestEnvToExtensions() {
-        // When:
-        api = new SystemTest(List.of(ext1, ext2), model, testEnv, services);
-
-        // Then:
-        verify(ext1).initialize(apiCapture.capture());
-        assertThat(apiCapture.getValue().testSuite(), is(sameInstance(testEnv)));
-
-        verify(ext2).initialize(apiCapture.capture());
-        assertThat(apiCapture.getValue().testSuite(), is(sameInstance(testEnv)));
-    }
-
-    @Test
     void shouldExposeServiceRegistry() {
         assertThat(api.services(), is(sameInstance(services)));
-    }
-
-    @Test
-    void shouldExposeServiceRegistryToExtensions() {
-        // When:
-        api = new SystemTest(List.of(ext1, ext2), model, testEnv, services);
-
-        // Then:
-        verify(ext1).initialize(apiCapture.capture());
-        assertThat(apiCapture.getValue().services(), is(sameInstance(services)));
-
-        verify(ext2).initialize(apiCapture.capture());
-        assertThat(apiCapture.getValue().services(), is(sameInstance(services)));
     }
 }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/listener/StartServicesUnderTestListenerTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/listener/StartServicesUnderTestListenerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.execution.listener;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mock.Strictness.LENIENT;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.function.Supplier;
+import org.creekservice.api.system.test.extension.model.CreekTestSuite;
+import org.creekservice.api.system.test.extension.service.ServiceInstance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StartServicesUnderTestListenerTest {
+
+    @Mock private CreekTestSuite suite;
+
+    @Mock(strictness = LENIENT)
+    private Supplier<List<ServiceInstance>> servicesSupplier;
+
+    @Mock private ServiceInstance instance0;
+    @Mock private ServiceInstance instance1;
+    @Mock private ServiceInstance instance2;
+    private StartServicesUnderTestListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new StartServicesUnderTestListener(servicesSupplier);
+
+        when(servicesSupplier.get()).thenReturn(List.of(instance0, instance1, instance2));
+    }
+
+    @Test
+    void shouldStartServicesBeforeSuiteInOrder() {
+        // When:
+        listener.beforeSuite(suite);
+
+        // Then:
+        final InOrder inOrder = inOrder(instance0, instance1, instance2);
+        inOrder.verify(instance0).start();
+        inOrder.verify(instance1).start();
+        inOrder.verify(instance2).start();
+    }
+
+    @Test
+    void shouldStopServicesAfterSuiteInReverseOrder() {
+        // Given:
+        listener.beforeSuite(suite);
+        when(servicesSupplier.get()).thenThrow(new AssertionError("Impl should cache instances"));
+
+        // When:
+        listener.afterSuite(suite);
+
+        // Then:
+        final InOrder inOrder = inOrder(instance0, instance1, instance2);
+        inOrder.verify(instance2).stop();
+        inOrder.verify(instance1).stop();
+        inOrder.verify(instance0).stop();
+    }
+
+    @Test
+    void shouldThrowOnServiceStartFailure() {
+        // Given:
+        final RuntimeException expected = new RuntimeException("Boom");
+        doThrow(expected).when(instance0).start();
+
+        // When:
+        final Exception e = assertThrows(RuntimeException.class, () -> listener.beforeSuite(suite));
+
+        // Then:
+        assertThat(e, is(sameInstance(expected)));
+    }
+
+    @Test
+    void shouldStopStartingServicesIfOnethrows() {
+        // Given:
+        doThrow(new RuntimeException("Boom")).when(instance1).start();
+
+        // When:
+        assertThrows(RuntimeException.class, () -> listener.beforeSuite(suite));
+
+        // Then:
+        verify(instance0).start();
+        verify(instance2, never()).start();
+    }
+
+    @Test
+    void shouldStopStartedServicesOnAfterSuiteEvenIfBeforeSuiteThrew() {
+        // Given:
+        doThrow(new RuntimeException("Boom")).when(instance1).start();
+        assertThrows(Exception.class, () -> listener.beforeSuite(suite));
+
+        // When:
+        listener.afterSuite(suite);
+
+        // Then:
+        verify(instance0).stop();
+        verify(instance1, never()).stop();
+        verify(instance2, never()).stop();
+    }
+}

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/listener/SuiteCleanUpListenerTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/listener/SuiteCleanUpListenerTest.java
@@ -31,22 +31,31 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class StopAllServicesTestLifecycleListenerTest {
+class SuiteCleanUpListenerTest {
 
     @Mock(answer = RETURNS_DEEP_STUBS)
     private SystemTest api;
 
-    private StopAllServicesTestLifecycleListener listener;
+    private SuiteCleanUpListener listener;
     @Mock private ServiceInstance service;
     @Captor private ArgumentCaptor<Consumer<? super ServiceInstance>> actionCaptor;
 
     @BeforeEach
     void setUp() {
-        listener = new StopAllServicesTestLifecycleListener(api);
+        listener = new SuiteCleanUpListener(api);
     }
 
     @Test
-    void shouldStopAllServices() {
+    void shouldClearTheServicesContainerBeforeSuite() {
+        // When:
+        listener.beforeSuite(null);
+
+        // Then:
+        verify(api.testSuite().services()).clear();
+    }
+
+    @Test
+    void shouldStopAllServicesAfterSuite() {
         // When:
         listener.afterSuite(null);
 

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceContainer.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceContainer.java
@@ -20,9 +20,15 @@ package org.creekservice.api.system.test.extension.service;
 public interface ServiceContainer extends ServiceCollection {
 
     /**
-     * Start an instance of a service.
+     * Add an instance of the service defined by the supplied {@code def}.
+     *
+     * <p>Adding the same service def multiple times will result in multiple service instances.
+     *
+     * <p>The newly added instance is not automatically started. Call {@link ServiceInstance#start()
+     * start} on the returned instance to start the service.
      *
      * @param def the def of the service to start.
+     * @return the service instance that was added.
      */
-    ServiceInstance start(ServiceDefinition def);
+    ServiceInstance add(ServiceDefinition def);
 }

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceInstance.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceInstance.java
@@ -19,6 +19,9 @@ package org.creekservice.api.system.test.extension.service;
 /** An instance of a {@link ServiceDefinition} */
 public interface ServiceInstance {
 
+    /** The unique name of the instance. */
+    String name();
+
     /** Start the instance. No-op if already started. */
     void start();
 


### PR DESCRIPTION
fixes: https://github.com/creek-service/creek-system-test/issues/60

Add, but don't start, service instances for the services under test _before_ the `beforeSuite()` method of any `TestLifecycleListener`'s that extensions add are invoked.

This will enable the extension's to add more info to the service instances before they are started, e.g. add environment variables telling the instances where remote services are. (The API for adding such details is TBD).

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended