### PR TITLE
Restructure testsuite services and add interface to modify service instances

### DIFF
--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/SystemTest.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/SystemTest.java
@@ -23,6 +23,9 @@ import java.util.Collection;
 import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.api.system.test.extension.CreekSystemTest;
+import org.creekservice.internal.system.test.executor.api.model.Model;
+import org.creekservice.internal.system.test.executor.api.service.ServiceDefinitions;
+import org.creekservice.internal.system.test.executor.api.testsuite.TestSuiteEnv;
 
 public final class SystemTest implements CreekSystemTest {
 

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/model/Model.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/model/Model.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.creekservice.internal.system.test.executor.api;
+package org.creekservice.internal.system.test.executor.api.model;
 
 import static java.util.Objects.requireNonNull;
 

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/service/ServiceDefinitions.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/service/ServiceDefinitions.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.creekservice.internal.system.test.executor.api;
+package org.creekservice.internal.system.test.executor.api.service;
 
 import static java.lang.System.lineSeparator;
 import static java.util.Objects.requireNonNull;

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/testsuite/TestSuiteEnv.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/testsuite/TestSuiteEnv.java
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-package org.creekservice.internal.system.test.executor.api;
+package org.creekservice.internal.system.test.executor.api.testsuite;
 
 import static java.util.Objects.requireNonNull;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.creekservice.api.base.annotation.VisibleForTesting;
-import org.creekservice.api.system.test.extension.test.TestSuiteEnvironment;
+import org.creekservice.api.system.test.extension.testsuite.TestSuiteEnvironment;
+import org.creekservice.internal.system.test.executor.api.testsuite.listeners.TestListeners;
+import org.creekservice.internal.system.test.executor.api.testsuite.service.LocalServiceInstances;
 
 public final class TestSuiteEnv implements TestSuiteEnvironment {
 

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/testsuite/listeners/TestListeners.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/testsuite/listeners/TestListeners.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.creekservice.internal.system.test.executor.api;
+package org.creekservice.internal.system.test.executor.api.testsuite.listeners;
 
+import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
@@ -23,8 +24,8 @@ import java.util.Iterator;
 import java.util.List;
 import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.base.type.Iterators;
-import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
-import org.creekservice.api.system.test.extension.test.TestListenerContainer;
+import org.creekservice.api.system.test.extension.testsuite.TestLifecycleListener;
+import org.creekservice.api.system.test.extension.testsuite.TestListenerContainer;
 
 public final class TestListeners implements TestListenerContainer {
 
@@ -43,7 +44,7 @@ public final class TestListeners implements TestListenerContainer {
     @Override
     public void append(final TestLifecycleListener listener) {
         throwIfNotOnCorrectThread();
-        listeners.add(listener);
+        listeners.add(requireNonNull(listener, "listener"));
     }
 
     @SuppressWarnings("NullableProblems")

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/testsuite/service/InstanceNaming.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/testsuite/service/InstanceNaming.java
@@ -14,18 +14,24 @@
  * limitations under the License.
  */
 
-package org.creekservice.api.system.test.extension.test;
+package org.creekservice.internal.system.test.executor.api.testsuite.service;
 
-/** Container of test package listeners */
-public interface TestListenerContainer extends TestListenerCollection {
 
-    /**
-     * Append the supplied {@code listener} to the end of the collection.
-     *
-     * <p>Listeners are invoked in order for {@code beforeXXXX} methods and in reverse order for
-     * {@code afterXXXX} methods.
-     *
-     * @param listener the listener to append.
-     */
-    void append(TestLifecycleListener listener);
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Naming strategy for service instances. */
+public final class InstanceNaming {
+
+    private final Map<String, AtomicInteger> names = new HashMap<>();
+
+    public String instanceName(final String serviceName) {
+        final AtomicInteger counter = names.computeIfAbsent(serviceName, k -> new AtomicInteger());
+        return serviceName + "-" + counter.getAndIncrement();
+    }
+
+    public void clear() {
+        names.clear();
+    }
 }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/testsuite/service/InstanceUnderTest.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/testsuite/service/InstanceUnderTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.api.testsuite.service;
+
+import static java.lang.System.lineSeparator;
+import static java.util.Objects.requireNonNull;
+import static org.creekservice.api.base.type.Preconditions.requireNonBlank;
+
+import java.util.ConcurrentModificationException;
+import org.creekservice.api.system.test.extension.service.ServiceInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/** An instance of one of the services under test. */
+final class InstanceUnderTest implements ServiceInstance {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceUnderTest.class);
+
+    private final long threadId;
+    private final String name;
+    private final DockerImageName imageName;
+    private final GenericContainer<?> container;
+    private String cachedContainerId;
+
+    InstanceUnderTest(
+            final String name,
+            final DockerImageName imageName,
+            final GenericContainer<?> container) {
+        this(name, imageName, container, Thread.currentThread().getId());
+    }
+
+    InstanceUnderTest(
+            final String name,
+            final DockerImageName imageName,
+            final GenericContainer<?> container,
+            final long threadId) {
+        this.threadId = threadId;
+        this.name = requireNonBlank(name, "name");
+        this.imageName = requireNonNull(imageName, "imageName");
+        this.container = requireNonNull(container, "container");
+        this.cachedContainerId = container.getContainerId();
+    }
+
+    @Override
+    public String name() {
+        throwIfNotOnCorrectThread();
+        return name;
+    }
+
+    @Override
+    public void start() {
+        if (running()) {
+            return;
+        }
+
+        LOGGER.info("Starting {} ({})", name, imageName);
+
+        try {
+            container.start();
+            cachedContainerId = container.getContainerId();
+
+            LOGGER.info("Started {} ({}) with container-id {}", name, imageName, cachedContainerId);
+        } catch (final Exception e) {
+            throw new FailedToStartServiceException(name, imageName, container, e);
+        }
+    }
+
+    @Override
+    public boolean running() {
+        throwIfNotOnCorrectThread();
+        return container.getContainerId() != null;
+    }
+
+    @Override
+    public void stop() {
+        if (!running()) {
+            return;
+        }
+
+        LOGGER.info("Stopping {} ({}) with container-id {}", name, imageName, cachedContainerId);
+        container.stop();
+        LOGGER.info("Stopped {} ({})", name, imageName);
+    }
+
+    @Override
+    public Modifier modify() {
+        throwIfNotOnCorrectThread();
+        throwIfRunning();
+        return null;
+    }
+
+    String cachedContainerId() {
+        return cachedContainerId;
+    }
+
+    private void throwIfRunning() {
+        if (running()) {
+            throw new IllegalStateException(
+                    "A service can not be modified when running. service: "
+                            + name
+                            + " ("
+                            + imageName
+                            + ") with container-id "
+                            + cachedContainerId);
+        }
+    }
+
+    private void throwIfNotOnCorrectThread() {
+        if (Thread.currentThread().getId() != threadId) {
+            throw new ConcurrentModificationException("Class is not thread safe");
+        }
+    }
+
+    private static final class FailedToStartServiceException extends RuntimeException {
+        FailedToStartServiceException(
+                final String name,
+                final DockerImageName imageName,
+                final GenericContainer<?> container,
+                final Throwable cause) {
+            super(
+                    "Failed to start service: "
+                            + name
+                            + ", image: "
+                            + imageName
+                            + lineSeparator()
+                            + "Cause: "
+                            + cause.getMessage()
+                            + lineSeparator()
+                            + "Logs: "
+                            + container.getLogs(),
+                    cause);
+        }
+    }
+}

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/TestCaseExecutor.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/TestCaseExecutor.java
@@ -18,7 +18,7 @@ package org.creekservice.internal.system.test.executor.execution;
 
 import static java.util.Objects.requireNonNull;
 
-import org.creekservice.api.system.test.extension.test.TestListenerCollection;
+import org.creekservice.api.system.test.extension.testsuite.TestListenerCollection;
 import org.creekservice.api.system.test.model.TestCase;
 
 public final class TestCaseExecutor {

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/TestSuiteExecutor.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/TestSuiteExecutor.java
@@ -19,7 +19,7 @@ package org.creekservice.internal.system.test.executor.execution;
 import static java.util.Objects.requireNonNull;
 
 import org.creekservice.api.base.annotation.VisibleForTesting;
-import org.creekservice.api.system.test.extension.test.TestListenerCollection;
+import org.creekservice.api.system.test.extension.testsuite.TestListenerCollection;
 import org.creekservice.api.system.test.model.TestSuite;
 import org.creekservice.internal.system.test.executor.result.TestSuiteResult;
 

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/AddServicesUnderTestListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/AddServicesUnderTestListener.java
@@ -23,7 +23,7 @@ import java.util.List;
 import org.creekservice.api.system.test.extension.model.CreekTestSuite;
 import org.creekservice.api.system.test.extension.service.ServiceDefinition;
 import org.creekservice.api.system.test.extension.service.ServiceInstance;
-import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
+import org.creekservice.api.system.test.extension.testsuite.TestLifecycleListener;
 import org.creekservice.internal.system.test.executor.api.SystemTest;
 
 /**

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/StartServicesUnderTestListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/StartServicesUnderTestListener.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import org.creekservice.api.system.test.extension.model.CreekTestSuite;
 import org.creekservice.api.system.test.extension.service.ServiceInstance;
-import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
+import org.creekservice.api.system.test.extension.testsuite.TestLifecycleListener;
 
 /**
  * A test lifecycle listener that is responsible for starting and stopping the services under test.

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/SuiteCleanUpListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/SuiteCleanUpListener.java
@@ -20,7 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.creekservice.api.system.test.extension.model.CreekTestSuite;
 import org.creekservice.api.system.test.extension.service.ServiceInstance;
-import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
+import org.creekservice.api.system.test.extension.testsuite.TestLifecycleListener;
 import org.creekservice.internal.system.test.executor.api.SystemTest;
 
 /**

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/observation/LoggingTestLifecycleListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/observation/LoggingTestLifecycleListener.java
@@ -19,7 +19,7 @@ package org.creekservice.internal.system.test.executor.observation;
 
 import org.creekservice.api.system.test.extension.model.CreekTestCase;
 import org.creekservice.api.system.test.extension.model.CreekTestSuite;
-import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
+import org.creekservice.api.system.test.extension.testsuite.TestLifecycleListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/executor/src/test/java/module-info.test
+++ b/executor/src/test/java/module-info.test
@@ -15,3 +15,18 @@
 
 --add-exports
   creek.system.test.executor/org.creekservice.internal.system.test.executor.api=guava.testlib
+
+--add-exports
+creek.system.test.executor/org.creekservice.internal.system.test.executor.api.model=guava.testlib
+
+--add-exports
+  creek.system.test.executor/org.creekservice.internal.system.test.executor.api.service=guava.testlib
+
+--add-exports
+  creek.system.test.executor/org.creekservice.internal.system.test.executor.api.testsuite=guava.testlib
+
+--add-exports
+  creek.system.test.executor/org.creekservice.internal.system.test.executor.api.testsuite.listeners=guava.testlib
+
+--add-exports
+  creek.system.test.executor/org.creekservice.internal.system.test.executor.api.testsuite.service=guava.testlib

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/model/ModelTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/model/ModelTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.creekservice.internal.system.test.executor.api;
+package org.creekservice.internal.system.test.executor.api.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/service/ServiceDefinitionsTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/service/ServiceDefinitionsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.creekservice.internal.system.test.executor.api;
+package org.creekservice.internal.system.test.executor.api.service;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -27,6 +27,7 @@ import static org.junit.jupiter.params.ParameterizedTest.INDEX_PLACEHOLDER;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.testing.NullPointerTester;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,6 +63,14 @@ class ServiceDefinitionsTest {
         when(serviceDescriptor0.name()).thenReturn("service-0");
 
         services = new ServiceDefinitions(List.of(serviceDescriptor0, serviceDescriptor1));
+    }
+
+    @Test
+    void shouldThrowNPEs() {
+        final NullPointerTester tester = new NullPointerTester();
+        tester.testAllPublicConstructors(ServiceDefinitions.class);
+        tester.testAllPublicStaticMethods(ServiceDefinitions.class);
+        tester.testAllPublicInstanceMethods(services);
     }
 
     @Test

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/TestEnvTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/TestEnvTest.java
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-package org.creekservice.internal.system.test.executor.api;
+package org.creekservice.internal.system.test.executor.api.testsuite;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 
 import com.google.common.testing.NullPointerTester;
-import org.creekservice.internal.system.test.executor.api.model.Model;
-import org.creekservice.internal.system.test.executor.api.service.ServiceDefinitions;
-import org.creekservice.internal.system.test.executor.api.testsuite.TestSuiteEnv;
+import org.creekservice.internal.system.test.executor.api.testsuite.listeners.TestListeners;
+import org.creekservice.internal.system.test.executor.api.testsuite.service.LocalServiceInstances;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,38 +30,32 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class SystemTestTest {
+class TestEnvTest {
 
-    @Mock private Model model;
-    @Mock private TestSuiteEnv testEnv;
-    @Mock private ServiceDefinitions services;
-    private SystemTest api;
+    @Mock private TestListeners listeners;
+    @Mock private LocalServiceInstances services;
+    private TestSuiteEnv testEnv;
 
     @BeforeEach
     void setUp() {
-        api = new SystemTest(model, testEnv, services);
+        testEnv = new TestSuiteEnv(listeners, services);
     }
 
     @Test
     void shouldThrowNPEs() {
         final NullPointerTester tester = new NullPointerTester();
-        tester.testAllPublicConstructors(SystemTest.class);
-        tester.testAllPublicStaticMethods(SystemTest.class);
-        tester.testAllPublicInstanceMethods(api);
+        tester.testAllPublicConstructors(TestSuiteEnv.class);
+        tester.testAllPublicStaticMethods(TestSuiteEnv.class);
+        tester.testAllPublicInstanceMethods(testEnv);
     }
 
     @Test
-    void shouldExposeModel() {
-        assertThat(api.model(), is(sameInstance(model)));
+    void shouldExposeListeners() {
+        assertThat(testEnv.listener(), is(sameInstance(listeners)));
     }
 
     @Test
-    void shouldExposeTestEnv() {
-        assertThat(api.testSuite(), is(sameInstance(testEnv)));
-    }
-
-    @Test
-    void shouldExposeServiceRegistry() {
-        assertThat(api.services(), is(sameInstance(services)));
+    void shouldExposeServices() {
+        assertThat(testEnv.services(), is(sameInstance(services)));
     }
 }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/listeners/TestListenersTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/listeners/TestListenersTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.creekservice.internal.system.test.executor.api;
+package org.creekservice.internal.system.test.executor.api.testsuite.listeners;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.ParameterizedTest.INDEX_PLACEHOLDER;
 import static org.mockito.Mockito.mock;
 
+import com.google.common.testing.NullPointerTester;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +32,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
+import org.creekservice.api.system.test.extension.testsuite.TestLifecycleListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,6 +52,14 @@ class TestListenersTest {
     @BeforeEach
     void setUp() {
         listeners = new TestListeners();
+    }
+
+    @Test
+    void shouldThrowNPEs() {
+        final NullPointerTester tester = new NullPointerTester();
+        tester.testAllPublicConstructors(TestListeners.class);
+        tester.testAllPublicStaticMethods(TestListeners.class);
+        tester.testAllPublicInstanceMethods(listeners);
     }
 
     @Test

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/service/InstanceNamingTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/service/InstanceNamingTest.java
@@ -14,37 +14,40 @@
  * limitations under the License.
  */
 
-package org.creekservice.internal.system.test.executor.api;
+package org.creekservice.internal.system.test.executor.api.testsuite.service;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class TestEnvTest {
+class InstanceNamingTest {
 
-    @Mock private TestListeners listeners;
-    @Mock private LocalServiceInstances services;
-    private TestSuiteEnv testEnv;
+    private InstanceNaming strategy;
 
     @BeforeEach
     void setUp() {
-        testEnv = new TestSuiteEnv(listeners, services);
+        strategy = new InstanceNaming();
     }
 
     @Test
-    void shouldExposeListeners() {
-        assertThat(testEnv.listener(), is(sameInstance(listeners)));
+    void shouldGenerateUniqueServiceNames() {
+        assertThat(strategy.instanceName("a"), is("a-0"));
+        assertThat(strategy.instanceName("a"), is("a-1"));
+        assertThat(strategy.instanceName("b"), is("b-0"));
+        assertThat(strategy.instanceName("a"), is("a-2"));
     }
 
     @Test
-    void shouldExposeServices() {
-        assertThat(testEnv.services(), is(sameInstance(services)));
+    void shouldClear() {
+        // Given:
+        strategy.instanceName("a");
+
+        // When:
+        strategy.clear();
+
+        // Then:
+        assertThat(strategy.instanceName("a"), is("a-0"));
     }
 }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/service/InstanceUnderTestTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/service/InstanceUnderTestTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.api.testsuite.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.ParameterizedTest.INDEX_PLACEHOLDER;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.testing.NullPointerTester;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@ExtendWith(MockitoExtension.class)
+class InstanceUnderTestTest {
+
+    private static final DockerImageName IMAGE_NAME =
+            DockerImageName.parse("ghcr.io/creekservice/test-service:latest");
+
+    @Mock private GenericContainer<?> container;
+
+    private InstanceUnderTest instance;
+
+    @BeforeEach
+    void setUp() {
+        instance = new InstanceUnderTest("a-0", IMAGE_NAME, container);
+    }
+
+    @Test
+    void shouldThrowNPEs() {
+        final NullPointerTester tester = new NullPointerTester();
+        tester.testAllPublicConstructors(InstanceUnderTest.class);
+        tester.testAllPublicStaticMethods(InstanceUnderTest.class);
+        tester.testAllPublicInstanceMethods(instance);
+    }
+
+    @Test
+    void shouldExposeName() {
+        assertThat(instance.name(), is("a-0"));
+    }
+
+    @Test
+    void shouldReportRunningIfContainerHasId() {
+        // Given:
+        when(container.getContainerId()).thenReturn("bob");
+
+        // Then:
+        assertThat(instance.running(), is(true));
+    }
+
+    @Test
+    void shouldReportNotRunningIfContainerHasNoId() {
+        // Given:
+        when(container.getContainerId()).thenReturn(null);
+
+        // Then:
+        assertThat(instance.running(), is(false));
+    }
+
+    @Test
+    void shouldStart() {
+        // Given:
+        when(container.getContainerId()).thenReturn(null);
+
+        // When:
+        instance.start();
+
+        // Then:
+        verify(container).start();
+    }
+
+    @Test
+    void shouldIgnoreStartIfRunning() {
+        // Given:
+        when(container.getContainerId()).thenReturn("bob");
+
+        // When:
+        instance.start();
+
+        // Then:
+        verify(container, never()).start();
+    }
+
+    @Test
+    void shouldCacheContainerIdOnStart() {
+        // Given:
+        when(container.getContainerId()).thenReturn(null).thenReturn("bob");
+
+        // When:
+        instance.start();
+
+        // Then:
+        assertThat(instance.cachedContainerId(), is("bob"));
+    }
+
+    @Test
+    void shouldStop() {
+        // Given:
+        when(container.getContainerId()).thenReturn("bob");
+
+        // When:
+        instance.stop();
+
+        // Then:
+        verify(container).stop();
+    }
+
+    @Test
+    void shouldIgnoreStopIfNotRunning() {
+        // Given:
+        when(container.getContainerId()).thenReturn(null);
+
+        // When:
+        instance.stop();
+
+        // Then:
+        verify(container, never()).stop();
+    }
+
+    @Test
+    void shouldNotClearCachedContainerIdOnStop() {
+        // Given:
+        when(container.getContainerId()).thenReturn(null).thenReturn("bob");
+
+        instance.start();
+
+        // When:
+        instance.stop();
+
+        // Then:
+        assertThat(instance.cachedContainerId(), is("bob"));
+    }
+
+    @Test
+    void shouldThrowOnServiceStartFailure() {
+        // Given:
+        final RuntimeException cause = new RuntimeException("Boom");
+        doThrow(cause).when(container).start();
+
+        // When:
+        final Exception e = assertThrows(RuntimeException.class, instance::start);
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                startsWith(
+                        "Failed to start service: a-0, image: ghcr.io/creekservice/test-service:latest"));
+        assertThat(e.getCause(), is(sameInstance(cause)));
+    }
+
+    @Test
+    void shouldThrowOnModifyIfRunning() {
+        // Given:
+        when(container.getContainerId()).thenReturn(null).thenReturn("bob");
+
+        instance.start();
+
+        // When:
+        final Exception e = assertThrows(IllegalStateException.class, instance::modify);
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is(
+                        "A service can not be modified when running. "
+                                + "service: a-0 (ghcr.io/creekservice/test-service:latest) with container-id bob"));
+    }
+
+    @SuppressWarnings("unused")
+    @ParameterizedTest(name = "[" + INDEX_PLACEHOLDER + "] {0}")
+    @MethodSource("publicMethods")
+    void shouldThrowIfWrongThread(final String ignored, final Consumer<InstanceUnderTest> method) {
+        // Given:
+        instance =
+                new InstanceUnderTest(
+                        "a-0", IMAGE_NAME, container, Thread.currentThread().getId() + 1);
+
+        // Then:
+        assertThrows(ConcurrentModificationException.class, () -> method.accept(instance));
+    }
+
+    @Test
+    void shouldHaveThreadingTestForEachPublicMethod() {
+        final List<String> publicMethodNames = publicMethodNames();
+        final int testedMethodCount = (int) publicMethods().count();
+        assertThat(
+                "Public methods:\n" + String.join(System.lineSeparator(), publicMethodNames),
+                testedMethodCount,
+                is(publicMethodNames.size()));
+    }
+
+    public static Stream<Arguments> publicMethods() {
+        return Stream.of(
+                Arguments.of("name", (Consumer<InstanceUnderTest>) InstanceUnderTest::name),
+                Arguments.of("start", (Consumer<InstanceUnderTest>) InstanceUnderTest::start),
+                Arguments.of("stop", (Consumer<InstanceUnderTest>) InstanceUnderTest::stop),
+                Arguments.of("running", (Consumer<InstanceUnderTest>) InstanceUnderTest::running),
+                Arguments.of("modify", (Consumer<InstanceUnderTest>) InstanceUnderTest::modify));
+    }
+
+    private List<String> publicMethodNames() {
+        return Arrays.stream(InstanceUnderTest.class.getMethods())
+                .filter(m -> !m.getDeclaringClass().equals(Object.class))
+                .map(Method::toGenericString)
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/TestCaseExecutorTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/TestCaseExecutorTest.java
@@ -26,8 +26,8 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 
 import java.util.function.Consumer;
-import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
-import org.creekservice.api.system.test.extension.test.TestListenerCollection;
+import org.creekservice.api.system.test.extension.testsuite.TestLifecycleListener;
+import org.creekservice.api.system.test.extension.testsuite.TestListenerCollection;
 import org.creekservice.api.system.test.model.TestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/TestSuiteExecutorTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/TestSuiteExecutorTest.java
@@ -28,8 +28,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.function.Consumer;
-import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
-import org.creekservice.api.system.test.extension.test.TestListenerCollection;
+import org.creekservice.api.system.test.extension.testsuite.TestLifecycleListener;
+import org.creekservice.api.system.test.extension.testsuite.TestListenerCollection;
 import org.creekservice.api.system.test.model.TestCase;
 import org.creekservice.api.system.test.model.TestSuite;
 import org.junit.jupiter.api.BeforeEach;

--- a/extension/src/main/java/module-info.java
+++ b/extension/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 module creek.system.test.extension {
     exports org.creekservice.api.system.test.extension;
     exports org.creekservice.api.system.test.extension.model;
-    exports org.creekservice.api.system.test.extension.test;
+    exports org.creekservice.api.system.test.extension.testsuite;
     exports org.creekservice.api.system.test.extension.service;
 
     uses org.creekservice.api.system.test.extension.CreekTestExtension;

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/CreekSystemTest.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/CreekSystemTest.java
@@ -19,7 +19,7 @@ package org.creekservice.api.system.test.extension;
 
 import org.creekservice.api.system.test.extension.model.ModelContainer;
 import org.creekservice.api.system.test.extension.service.ServiceDefinitionCollection;
-import org.creekservice.api.system.test.extension.test.TestSuiteEnvironment;
+import org.creekservice.api.system.test.extension.testsuite.TestSuiteEnvironment;
 
 /** API to the system tests exposed to extensions */
 public interface CreekSystemTest {

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceInstance.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceInstance.java
@@ -16,6 +16,9 @@
 
 package org.creekservice.api.system.test.extension.service;
 
+
+import java.util.Map;
+
 /** An instance of a {@link ServiceDefinition} */
 public interface ServiceInstance {
 
@@ -30,4 +33,36 @@ public interface ServiceInstance {
 
     /** Stop the instance. No-op if already stopped. */
     void stop();
+
+    /**
+     * Amend the definition of the service instance.
+     *
+     * <p>**Note**: this method can not be called while the instance is running.
+     *
+     * @return type used to modify the instance.
+     */
+    Modifier modify();
+
+    interface Modifier {
+
+        /**
+         * Set an environment variable on the instance.
+         *
+         * @param name the name of the environment variable.
+         * @param value the value of the environment variable.
+         * @return self, for method chaining.
+         */
+        Modifier addEnv(String name, String value);
+
+        /**
+         * Set environment variables on the instance.
+         *
+         * @param env the map of environment variables to add.
+         * @return self, for method chaining.
+         */
+        default Modifier addEnv(Map<String, String> env) {
+            env.forEach(this::addEnv);
+            return this;
+        }
+    }
 }

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/testsuite/TestLifecycleListener.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/testsuite/TestLifecycleListener.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.creekservice.api.system.test.extension.test;
+package org.creekservice.api.system.test.extension.testsuite;
 
 
 import org.creekservice.api.system.test.extension.model.CreekTestCase;

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/testsuite/TestListenerCollection.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/testsuite/TestListenerCollection.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.creekservice.api.system.test.extension.test;
+package org.creekservice.api.system.test.extension.testsuite;
 
 import static java.util.Objects.requireNonNull;
 

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/testsuite/TestListenerContainer.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/testsuite/TestListenerContainer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.system.test.extension.testsuite;
+
+/** Container of test package listeners */
+public interface TestListenerContainer extends TestListenerCollection {
+
+    /**
+     * Append the supplied {@code listener} to the end of the collection.
+     *
+     * <p>Listeners are invoked in order for {@code beforeXXXX} methods and in reverse order for
+     * {@code afterXXXX} methods.
+     *
+     * @param listener the listener to append.
+     */
+    void append(TestLifecycleListener listener);
+}

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/testsuite/TestSuiteEnvironment.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/testsuite/TestSuiteEnvironment.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.creekservice.api.system.test.extension.test;
+package org.creekservice.api.system.test.extension.testsuite;
 
 
 import org.creekservice.api.system.test.extension.service.ServiceContainer;

--- a/extension/src/test/java/module-info.test
+++ b/extension/src/test/java/module-info.test
@@ -15,3 +15,6 @@
 
 --add-opens
   creek.system.test.extension/org.creekservice.api.system.test.extension.model=org.mockito
+
+--add-opens
+  creek.system.test.extension/org.creekservice.api.system.test.extension.testsuite=org.mockito

--- a/extension/src/test/java/org/creekservice/api/system/test/extension/testsuite/TestLifecycleListenerTest.java
+++ b/extension/src/test/java/org/creekservice/api/system/test/extension/testsuite/TestLifecycleListenerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.creekservice.api.system.test.extension.model;
+package org.creekservice.api.system.test.extension.testsuite;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -27,7 +27,8 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
+import org.creekservice.api.system.test.extension.model.CreekTestCase;
+import org.creekservice.api.system.test.extension.model.CreekTestSuite;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/extension/src/test/java/org/creekservice/api/system/test/extension/testsuite/TestListenerCollectionTest.java
+++ b/extension/src/test/java/org/creekservice/api/system/test/extension/testsuite/TestListenerCollectionTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.creekservice.api.system.test.extension.model;
+package org.creekservice.api.system.test.extension.testsuite;
 
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -23,8 +23,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 import org.creekservice.api.base.type.Iterators;
-import org.creekservice.api.system.test.extension.test.TestLifecycleListener;
-import org.creekservice.api.system.test.extension.test.TestListenerCollection;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;


### PR DESCRIPTION
- Move classes into more specific packages
- Decompose `LocalServiceInstances` into multiple files
- Enhance `ServiceInstance` with the start of an interface to allow extensions to modify instances.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended