### PR TITLE
More generic service container

### DIFF
--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/testsuite/service/ComponentInstance.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/testsuite/service/ComponentInstance.java
@@ -28,24 +28,24 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
-/** An instance of one of the services under test. */
-final class InstanceUnderTest implements ServiceInstance, ServiceInstance.Modifier {
+/** An instance of a service running in a local docker container. */
+final class ComponentInstance implements ServiceInstance, ServiceInstance.Modifier {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceUnderTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ComponentInstance.class);
 
     private final long threadId;
     private final String name;
     private final DockerImageName imageName;
     private final GenericContainer<?> container;
 
-    InstanceUnderTest(
+    ComponentInstance(
             final String name,
             final DockerImageName imageName,
             final GenericContainer<?> container) {
         this(name, imageName, container, Thread.currentThread().getId());
     }
 
-    InstanceUnderTest(
+    ComponentInstance(
             final String name,
             final DockerImageName imageName,
             final GenericContainer<?> container,

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/testsuite/service/InstanceNaming.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/testsuite/service/InstanceNaming.java
@@ -16,6 +16,7 @@
 
 package org.creekservice.internal.system.test.executor.api.testsuite.service;
 
+import static java.util.Objects.requireNonNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,6 +28,7 @@ public final class InstanceNaming {
     private final Map<String, AtomicInteger> names = new HashMap<>();
 
     public String instanceName(final String serviceName) {
+        requireNonNull(serviceName, "serviceName");
         final AtomicInteger counter = names.computeIfAbsent(serviceName, k -> new AtomicInteger());
         return serviceName + "-" + counter.getAndIncrement();
     }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/service/ComponentInstanceTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/service/ComponentInstanceTest.java
@@ -48,25 +48,25 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @ExtendWith(MockitoExtension.class)
-class InstanceUnderTestTest {
+class ComponentInstanceTest {
 
     private static final DockerImageName IMAGE_NAME =
             DockerImageName.parse("ghcr.io/creekservice/test-service:latest");
 
     @Mock private GenericContainer<?> container;
 
-    private InstanceUnderTest instance;
+    private ComponentInstance instance;
 
     @BeforeEach
     void setUp() {
-        instance = new InstanceUnderTest("a-0", IMAGE_NAME, container);
+        instance = new ComponentInstance("a-0", IMAGE_NAME, container);
     }
 
     @Test
     void shouldThrowNPEs() {
         final NullPointerTester tester = new NullPointerTester();
-        tester.testAllPublicConstructors(InstanceUnderTest.class);
-        tester.testAllPublicStaticMethods(InstanceUnderTest.class);
+        tester.testAllPublicConstructors(ComponentInstance.class);
+        tester.testAllPublicStaticMethods(ComponentInstance.class);
         tester.testAllPublicInstanceMethods(instance);
     }
 
@@ -220,10 +220,10 @@ class InstanceUnderTestTest {
     @SuppressWarnings("unused")
     @ParameterizedTest(name = "[" + INDEX_PLACEHOLDER + "] {0}")
     @MethodSource("publicMethods")
-    void shouldThrowIfWrongThread(final String ignored, final Consumer<InstanceUnderTest> method) {
+    void shouldThrowIfWrongThread(final String ignored, final Consumer<ComponentInstance> method) {
         // Given:
         instance =
-                new InstanceUnderTest(
+                new ComponentInstance(
                         "a-0", IMAGE_NAME, container, Thread.currentThread().getId() + 1);
 
         // Then:
@@ -246,22 +246,22 @@ class InstanceUnderTestTest {
 
     public static Stream<Arguments> publicMethods() {
         return Stream.of(
-                Arguments.of("name", (Consumer<InstanceUnderTest>) InstanceUnderTest::name),
-                Arguments.of("start", (Consumer<InstanceUnderTest>) InstanceUnderTest::start),
-                Arguments.of("stop", (Consumer<InstanceUnderTest>) InstanceUnderTest::stop),
-                Arguments.of("running", (Consumer<InstanceUnderTest>) InstanceUnderTest::running),
-                Arguments.of("modify", (Consumer<InstanceUnderTest>) InstanceUnderTest::modify),
-                Arguments.of("withEnv", (Consumer<InstanceUnderTest>) i -> i.withEnv("k", "v")),
+                Arguments.of("name", (Consumer<ComponentInstance>) ComponentInstance::name),
+                Arguments.of("start", (Consumer<ComponentInstance>) ComponentInstance::start),
+                Arguments.of("stop", (Consumer<ComponentInstance>) ComponentInstance::stop),
+                Arguments.of("running", (Consumer<ComponentInstance>) ComponentInstance::running),
+                Arguments.of("modify", (Consumer<ComponentInstance>) ComponentInstance::modify),
+                Arguments.of("withEnv", (Consumer<ComponentInstance>) i -> i.withEnv("k", "v")),
                 Arguments.of(
                         "withEnv(Map)",
-                        (Consumer<InstanceUnderTest>) i -> i.withEnv(Map.of("k", "v"))),
+                        (Consumer<ComponentInstance>) i -> i.withEnv(Map.of("k", "v"))),
                 Arguments.of(
                         "withExposedPorts",
-                        (Consumer<InstanceUnderTest>) InstanceUnderTest::withExposedPorts));
+                        (Consumer<ComponentInstance>) ComponentInstance::withExposedPorts));
     }
 
     private List<String> publicMethodNames() {
-        return Arrays.stream(InstanceUnderTest.class.getMethods())
+        return Arrays.stream(ComponentInstance.class.getMethods())
                 .filter(m -> !m.getDeclaringClass().equals(Object.class))
                 .map(Method::toGenericString)
                 .collect(Collectors.toUnmodifiableList());

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/service/InstanceNamingTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/service/InstanceNamingTest.java
@@ -19,6 +19,7 @@ package org.creekservice.internal.system.test.executor.api.testsuite.service;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import com.google.common.testing.NullPointerTester;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +30,14 @@ class InstanceNamingTest {
     @BeforeEach
     void setUp() {
         strategy = new InstanceNaming();
+    }
+
+    @Test
+    void shouldThrowNPEs() {
+        final NullPointerTester tester = new NullPointerTester();
+        tester.testAllPublicConstructors(InstanceNaming.class);
+        tester.testAllPublicStaticMethods(InstanceNaming.class);
+        tester.testAllPublicInstanceMethods(strategy);
     }
 
     @Test

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/service/LocalServiceInstancesTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/testsuite/service/LocalServiceInstancesTest.java
@@ -92,6 +92,10 @@ class LocalServiceInstancesTest {
                         (Consumer<LocalServiceInstances>)
                                 si -> si.add(mock(ServiceDefinition.class))),
                 Arguments.of(
+                        "add",
+                        (Consumer<LocalServiceInstances>)
+                                si -> si.add("service-name", "image-name")),
+                Arguments.of(
                         "forEach",
                         (Consumer<LocalServiceInstances>) si -> si.forEach(mock(Consumer.class))));
     }

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceContainer.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/service/ServiceContainer.java
@@ -30,5 +30,26 @@ public interface ServiceContainer extends ServiceCollection {
      * @param def the def of the service to start.
      * @return the service instance that was added.
      */
-    ServiceInstance add(ServiceDefinition def);
+    default ServiceInstance add(ServiceDefinition def) {
+        return add(def.name(), def.dockerImage() + ":latest");
+    }
+
+    /**
+     * Add a service instance to the container.
+     *
+     * <p>The name of the instance will be the supplied {@code serviceName} with a instance number
+     * suffix. For example, adding a service named {@code finance-service} will result in an
+     * instance named {@code finance-service-0}.
+     *
+     * <p>Adding the same service name multiple times will result in multiple service instances, for
+     * example {@code finance-service-0}, {@code finance-service-1}, etc.
+     *
+     * <p>The newly added instance is not automatically started. Call {@link ServiceInstance#start()
+     * start} on the returned instance to start the service.
+     *
+     * @param serviceName the name of the service, e.g. {@code finance-service}.
+     * @param dockerImageName the full docker image name of the service.
+     * @return the service instance that was added.
+     */
+    ServiceInstance add(String serviceName, String dockerImageName);
 }


### PR DESCRIPTION
part of: https://github.com/creek-service/creek-system-test/issues/10

Allow services to be added to the environment without a `ServiceDefinition`. Instead,
just require the service name and docker image name.

This will allow extensions to start other services, e.g. Kafka, that the services under test need.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended