### PR TITLE
Remove validate call from `ResourceHandler`.

### DIFF
--- a/executor/src/test/java/org/creekservice/api/system/test/executor/SystemTestExecutorFunctionalTest.java
+++ b/executor/src/test/java/org/creekservice/api/system/test/executor/SystemTestExecutorFunctionalTest.java
@@ -320,27 +320,6 @@ class SystemTestExecutorFunctionalTest {
     }
 
     @Test
-    void shouldValidateResourceGroupsDuring() {
-        // Given:
-        givenResult(ExpectedResult.SUCCESS);
-
-        // When:
-        runExecutor(minimalArgs());
-
-        // Then:
-        assertThat(
-                stdOut.get(), containsString("Validating resource group: test://shared, count: 1"));
-        assertThat(
-                stdOut.get(),
-                containsString("Validating resource group: test://internal, count: 1"));
-        assertThat(
-                stdOut.get(), containsString("Validating resource group: test://output, count: 1"));
-        assertThat(
-                stdOut.get(),
-                containsString("Validating resource group: test://upstream, count: 2"));
-    }
-
-    @Test
     void shouldReportReportValidationFailure() {
         // Given:
         givenResult(ExpectedResult.SUCCESS);
@@ -437,7 +416,7 @@ class SystemTestExecutorFunctionalTest {
 
             stdErr = Suppliers.memoize(() -> readAll(executor.getErrorStream()));
             stdOut = Suppliers.memoize(() -> readAll(executor.getInputStream()));
-            executor.waitFor(30, TimeUnit.SECONDS);
+            executor.waitFor(1, TimeUnit.MINUTES);
             return executor.exitValue();
         } catch (final Exception e) {
             throw new AssertionError("Error executing: " + cmd, e);


### PR DESCRIPTION
part of: https://github.com/creek-service/creek-kafka/issues/56

Given a service extension will be passed all components under test as part of the api passed to the initialize call, and that the extension will use the components' resource descriptors to initialize itself, and will therefore need to validate descriptors and that this is done _before_ the resource initializer can call validate... there is no point to then calling validate again here.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended