### PR TITLE
Expose options to system test extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ To test the system, we may want to seed the test environment with some initial _
 ```yaml
 ---
 '@type': kafka_topic
-description: Seed environment with base set of user data
+notes: Seed environment with base set of user data
 topic: user
 records:
   - key: 1876

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/Api.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/Api.java
@@ -51,8 +51,8 @@ public final class Api {
         final AddServicesUnderTestListener addServicesListener =
                 new AddServicesUnderTestListener(api);
         api.tests().env().listeners().append(addServicesListener);
-        api.tests().env().listeners().append(new InitializeResourcesListener(api));
         creekTestExtensions.forEach(ext -> ext.initialize(api));
+        api.tests().env().listeners().append(new InitializeResourcesListener(api));
         api.tests()
                 .env()
                 .listeners()

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/SystemTest.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/SystemTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.api.service.extension.CreekExtension;
+import org.creekservice.api.service.extension.CreekExtensionOptions;
 import org.creekservice.api.service.extension.CreekExtensionProvider;
 import org.creekservice.api.service.extension.component.model.ComponentModelCollection;
 import org.creekservice.api.system.test.extension.CreekSystemTest;
@@ -68,16 +69,19 @@ public final class SystemTest implements CreekSystemTest {
         this.extensions = new Extensions(api.apply(components));
     }
 
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intentional exposure")
     @Override
     public Tests tests() {
         return tests;
     }
 
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intentional exposure")
     @Override
     public Components components() {
         return components;
     }
 
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intentional exposure")
     @Override
     public Extensions extensions() {
         return extensions;
@@ -162,6 +166,11 @@ public final class SystemTest implements CreekSystemTest {
 
         Extensions(final Creek api) {
             this.api = requireNonNull(api, "api");
+        }
+
+        @Override
+        public void addOption(final CreekExtensionOptions option) {
+            api.options().add(option);
         }
 
         @Override

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/ApiTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/ApiTest.java
@@ -70,15 +70,14 @@ class ApiTest {
     @Test
     void shouldAddAddServicesUnderTestListener() {
         // When:
-        initializeApi(api, List.of());
+        initializeApi(api, List.of(ext0));
 
         // Then:
-        final InOrder inOrder = inOrder(api.tests().env().listeners());
+        final InOrder inOrder = inOrder(api.tests().env().listeners(), ext0);
         inOrder.verify(api.tests().env().listeners()).append(isA(SuiteCleanUpListener.class));
         inOrder.verify(api.tests().env().listeners())
                 .append(isA(AddServicesUnderTestListener.class));
-        inOrder.verify(api.tests().env().listeners())
-                .append(isA(InitializeResourcesListener.class));
+        inOrder.verify(ext0).initialize(api);
     }
 
     @Test
@@ -88,11 +87,11 @@ class ApiTest {
 
         // Then:
         final InOrder inOrder = inOrder(api.tests().env().listeners(), ext0);
-        inOrder.verify(api.tests().env().listeners())
-                .append(isA(AddServicesUnderTestListener.class));
+        inOrder.verify(ext0).initialize(api);
         inOrder.verify(api.tests().env().listeners())
                 .append(isA(InitializeResourcesListener.class));
-        inOrder.verify(ext0).initialize(api);
+        inOrder.verify(api.tests().env().listeners())
+                .append(isA(StartServicesUnderTestListener.class));
     }
 
     @Test
@@ -103,11 +102,11 @@ class ApiTest {
         // Then:
         final InOrder inOrder = inOrder(api.tests().env().listeners(), ext0, ext1);
         inOrder.verify(api.tests().env().listeners())
-                .append(isA(InitializeResourcesListener.class));
+                .append(isA(AddServicesUnderTestListener.class));
         inOrder.verify(ext0).initialize(api);
         inOrder.verify(ext1).initialize(api);
         inOrder.verify(api.tests().env().listeners())
-                .append(isA(StartServicesUnderTestListener.class));
+                .append(isA(InitializeResourcesListener.class));
     }
 
     @Test

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/SystemTestTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/SystemTestTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.testing.NullPointerTester;
 import java.util.function.Function;
 import org.creekservice.api.service.extension.CreekExtension;
+import org.creekservice.api.service.extension.CreekExtensionOptions;
 import org.creekservice.api.service.extension.CreekExtensionProvider;
 import org.creekservice.api.system.test.extension.component.definition.AggregateDefinition;
 import org.creekservice.api.system.test.extension.component.definition.ServiceDefinition;
@@ -89,6 +90,18 @@ class SystemTestTest {
     @Test
     void shouldExposeAggregateDefinitions() {
         assertThat(api.components().definitions().aggregates(), is(sameInstance(aggregates)));
+    }
+
+    @Test
+    void shouldAddOptions() {
+        // Given:
+        final CreekExtensionOptions option = mock(CreekExtensionOptions.class);
+
+        // When:
+        api.extensions().addOption(option);
+
+        // Then:
+        verify(serviceApi.options()).add(option);
     }
 
     @SuppressWarnings("unchecked")

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/CreekSystemTest.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/CreekSystemTest.java
@@ -19,6 +19,7 @@ package org.creekservice.api.system.test.extension;
 
 import java.util.stream.Stream;
 import org.creekservice.api.service.extension.CreekExtension;
+import org.creekservice.api.service.extension.CreekExtensionOptions;
 import org.creekservice.api.service.extension.CreekExtensionProvider;
 import org.creekservice.api.system.test.extension.component.definition.AggregateDefinition;
 import org.creekservice.api.system.test.extension.component.definition.ComponentDefinition;
@@ -57,6 +58,15 @@ public interface CreekSystemTest {
     ExtensionAccessor extensions();
 
     interface ExtensionAccessor {
+
+        /**
+         * Register an extensions option set.
+         *
+         * <p>Allows customisation of service extensions added via {@link #ensureExtension}
+         *
+         * @param option the options to add.
+         */
+        void addOption(CreekExtensionOptions option);
 
         /**
          * Ensure an extension has been initialized.

--- a/model/src/main/java/org/creekservice/api/system/test/model/TestCaseDef.java
+++ b/model/src/main/java/org/creekservice/api/system/test/model/TestCaseDef.java
@@ -35,7 +35,7 @@ import org.creekservice.api.system.test.extension.test.model.InputRef;
 public final class TestCaseDef implements LocationAware<TestCaseDef> {
 
     private final String name;
-    private final String description;
+    private final String notes;
     private final Optional<Disabled> disabled;
     private final List<InputRef> inputs;
     private final List<ExpectationRef> expectations;
@@ -45,7 +45,7 @@ public final class TestCaseDef implements LocationAware<TestCaseDef> {
     @JsonCreator
     public static TestCaseDef testCase(
             @JsonProperty(value = "name", required = true) final String name,
-            @JsonProperty("description") final Optional<String> description,
+            @JsonProperty("notes") final Optional<String> notes,
             @JsonProperty("disabled") final Optional<Disabled> disabled,
             @JsonProperty("inputs") final Optional<? extends List<? extends InputRef>> maybeInputs,
             @JsonProperty(value = "expectations", required = true)
@@ -53,18 +53,18 @@ public final class TestCaseDef implements LocationAware<TestCaseDef> {
         final List<? extends InputRef> inputs =
                 maybeInputs.isPresent() ? maybeInputs.get() : List.of();
         return new TestCaseDef(
-                name, description.orElse(""), disabled, UNKNOWN_LOCATION, inputs, expectations);
+                name, notes.orElse(""), disabled, UNKNOWN_LOCATION, inputs, expectations);
     }
 
     private TestCaseDef(
             final String name,
-            final String description,
+            final String notes,
             final Optional<Disabled> disabled,
             final URI location,
             final List<? extends InputRef> inputs,
             final List<? extends ExpectationRef> expectations) {
         this.name = requireNonNull(name, "name");
-        this.description = requireNonNull(description, "description");
+        this.notes = requireNonNull(notes, "notes");
         this.disabled = requireNonNull(disabled, "disabled");
         this.location = requireNonNull(location, "location");
         this.inputs = List.copyOf(requireNonNull(inputs, "inputs"));
@@ -80,10 +80,10 @@ public final class TestCaseDef implements LocationAware<TestCaseDef> {
         return name;
     }
 
-    @JsonGetter("description")
-    @JsonPropertyDescription("Optional description")
-    public String description() {
-        return description;
+    @JsonGetter("notes")
+    @JsonPropertyDescription("Optional notes")
+    public String notes() {
+        return notes;
     }
 
     @JsonGetter("disabled")
@@ -110,7 +110,7 @@ public final class TestCaseDef implements LocationAware<TestCaseDef> {
     }
 
     public TestCaseDef withLocation(final URI location) {
-        return new TestCaseDef(name, description, disabled, location, inputs, expectations);
+        return new TestCaseDef(name, notes, disabled, location, inputs, expectations);
     }
 
     @Override
@@ -125,7 +125,7 @@ public final class TestCaseDef implements LocationAware<TestCaseDef> {
 
         // Note: location intentionally excluded:
         return Objects.equals(name, testCase.name)
-                && Objects.equals(description, testCase.description)
+                && Objects.equals(notes, testCase.notes)
                 && Objects.equals(disabled, testCase.disabled)
                 && Objects.equals(inputs, testCase.inputs)
                 && Objects.equals(expectations, testCase.expectations);
@@ -134,7 +134,7 @@ public final class TestCaseDef implements LocationAware<TestCaseDef> {
     @Override
     public int hashCode() {
         // Note: location intentionally excluded:
-        return Objects.hash(name, description, disabled, inputs, expectations);
+        return Objects.hash(name, notes, disabled, inputs, expectations);
     }
 
     @Override
@@ -143,8 +143,8 @@ public final class TestCaseDef implements LocationAware<TestCaseDef> {
                 + "name='"
                 + name
                 + '\''
-                + ", description='"
-                + description
+                + ", notes='"
+                + notes
                 + '\''
                 + ", disabled="
                 + disabled

--- a/model/src/main/java/org/creekservice/api/system/test/model/TestSuiteDef.java
+++ b/model/src/main/java/org/creekservice/api/system/test/model/TestSuiteDef.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 public final class TestSuiteDef implements LocationAware<TestSuiteDef> {
 
     private final String name;
-    private final String description;
+    private final String notes;
     private final Optional<Disabled> disabled;
     private final List<String> services;
     private final List<TestCaseDef> tests;
@@ -42,23 +42,23 @@ public final class TestSuiteDef implements LocationAware<TestSuiteDef> {
     @JsonCreator
     public static TestSuiteDef testSuite(
             @JsonProperty(value = "name", required = true) final String name,
-            @JsonProperty("description") final Optional<String> description,
+            @JsonProperty("notes") final Optional<String> notes,
             @JsonProperty("disabled") final Optional<Disabled> disabled,
             @JsonProperty(value = "services", required = true) final List<String> services,
             @JsonProperty(value = "tests", required = true) final List<TestCaseDef> tests) {
         return new TestSuiteDef(
-                name, description.orElse(""), disabled, UNKNOWN_LOCATION, services, tests);
+                name, notes.orElse(""), disabled, UNKNOWN_LOCATION, services, tests);
     }
 
     private TestSuiteDef(
             final String name,
-            final String description,
+            final String notes,
             final Optional<Disabled> disabled,
             final URI location,
             final List<String> services,
             final List<TestCaseDef> tests) {
         this.name = requireNonNull(name, "name");
-        this.description = requireNonNull(description, "description");
+        this.notes = requireNonNull(notes, "notes");
         this.disabled = requireNonNull(disabled, "disabled");
         this.location = requireNonNull(location, "location");
         this.services = List.copyOf(requireNonNull(services, "services"));
@@ -75,10 +75,10 @@ public final class TestSuiteDef implements LocationAware<TestSuiteDef> {
         return name;
     }
 
-    @JsonGetter("description")
-    @JsonPropertyDescription("(Optional) description")
-    public String description() {
-        return description;
+    @JsonGetter("notes")
+    @JsonPropertyDescription("(Optional) notes")
+    public String notes() {
+        return notes;
     }
 
     @JsonGetter("disabled")
@@ -107,7 +107,7 @@ public final class TestSuiteDef implements LocationAware<TestSuiteDef> {
     }
 
     public TestSuiteDef withLocation(final URI location) {
-        return new TestSuiteDef(name, description, disabled, location, services, tests);
+        return new TestSuiteDef(name, notes, disabled, location, services, tests);
     }
 
     @Override
@@ -122,7 +122,7 @@ public final class TestSuiteDef implements LocationAware<TestSuiteDef> {
 
         // Note: location intentionally excluded:
         return Objects.equals(name, testSuiteDef.name)
-                && Objects.equals(description, testSuiteDef.description)
+                && Objects.equals(notes, testSuiteDef.notes)
                 && Objects.equals(disabled, testSuiteDef.disabled)
                 && Objects.equals(services, testSuiteDef.services)
                 && Objects.equals(tests, testSuiteDef.tests);
@@ -131,7 +131,7 @@ public final class TestSuiteDef implements LocationAware<TestSuiteDef> {
     @Override
     public int hashCode() {
         // Note: location intentionally excluded:
-        return Objects.hash(name, description, disabled, services, tests);
+        return Objects.hash(name, notes, disabled, services, tests);
     }
 
     @Override
@@ -140,8 +140,8 @@ public final class TestSuiteDef implements LocationAware<TestSuiteDef> {
                 + "name='"
                 + name
                 + '\''
-                + ", description='"
-                + description
+                + ", notes='"
+                + notes
                 + '\''
                 + ", disabled="
                 + disabled

--- a/model/src/test/java/org/creekservice/api/system/test/model/TestCaseDefTest.java
+++ b/model/src/test/java/org/creekservice/api/system/test/model/TestCaseDefTest.java
@@ -63,19 +63,19 @@ class TestCaseDefTest {
                 .addEqualityGroup(
                         testCase(
                                 "name",
-                                Optional.of("description"),
+                                Optional.of("notes"),
                                 Optional.of(disabled),
                                 inputs,
                                 expectations),
                         testCase(
                                 "name",
-                                Optional.of("description"),
+                                Optional.of("notes"),
                                 Optional.of(disabled),
                                 inputs,
                                 expectations),
                         testCase(
                                         "name",
-                                        Optional.of("description"),
+                                        Optional.of("notes"),
                                         Optional.of(disabled),
                                         inputs,
                                         expectations)
@@ -83,7 +83,7 @@ class TestCaseDefTest {
                 .addEqualityGroup(
                         testCase(
                                 "diff",
-                                Optional.of("description"),
+                                Optional.of("notes"),
                                 Optional.of(disabled),
                                 inputs,
                                 expectations))
@@ -97,21 +97,21 @@ class TestCaseDefTest {
                 .addEqualityGroup(
                         testCase(
                                 "name",
-                                Optional.of("description"),
+                                Optional.of("notes"),
                                 Optional.empty(),
                                 inputs,
                                 expectations))
                 .addEqualityGroup(
                         testCase(
                                 "name",
-                                Optional.of("description"),
+                                Optional.of("notes"),
                                 Optional.of(disabled),
                                 Optional.empty(),
                                 expectations))
                 .addEqualityGroup(
                         testCase(
                                 "name",
-                                Optional.of("description"),
+                                Optional.of("notes"),
                                 Optional.of(disabled),
                                 inputs,
                                 List.of(expectations.get(0), expectations.get(0))))
@@ -124,7 +124,7 @@ class TestCaseDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test case\n"
-                        + "description: description\n"
+                        + "notes: description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "inputs:\n"
@@ -137,7 +137,7 @@ class TestCaseDefTest {
 
         // Then:
         assertThat(result.name(), is("a test case"));
-        assertThat(result.description(), is("description"));
+        assertThat(result.notes(), is("description"));
         assertThat(result.disabled().map(Disabled::reason), is(Optional.of("disabled reason")));
         assertThat(result.inputs(), contains(simpleRef("an_input")));
         assertThat(result.expectations(), contains(simpleRef("an_expectation")));
@@ -149,7 +149,7 @@ class TestCaseDefTest {
         // Given:
         final String yaml =
                 "---\n"
-                        + "description: description\n"
+                        + "notes: description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "inputs:\n"
@@ -181,7 +181,7 @@ class TestCaseDefTest {
         final TestCaseDef result = parse(yaml);
 
         // Then:
-        assertThat(result.description(), is(""));
+        assertThat(result.notes(), is(""));
     }
 
     @Test
@@ -190,7 +190,7 @@ class TestCaseDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test case\n"
-                        + "description: description\n"
+                        + "notes: description\n"
                         + "inputs:\n"
                         + "  - an_input\n"
                         + "expectations:\n"
@@ -209,7 +209,7 @@ class TestCaseDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test case\n"
-                        + "description: description\n"
+                        + "notes: description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "expectations:\n"
@@ -228,7 +228,7 @@ class TestCaseDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test case\n"
-                        + "description: description\n"
+                        + "notes: description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "inputs:\n"
@@ -248,7 +248,7 @@ class TestCaseDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test case\n"
-                        + "description: description\n"
+                        + "notes: description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "inputs:\n"
@@ -268,7 +268,7 @@ class TestCaseDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test case\n"
-                        + "description: description\n"
+                        + "notes: description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "inputs:\n"
@@ -291,7 +291,7 @@ class TestCaseDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test case\n"
-                        + "description: description\n"
+                        + "notes: description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "inputs:\n"
@@ -314,7 +314,7 @@ class TestCaseDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test case\n"
-                        + "description: description\n"
+                        + "notes: description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "inputs:\n"

--- a/model/src/test/java/org/creekservice/api/system/test/model/TestSuiteDefTest.java
+++ b/model/src/test/java/org/creekservice/api/system/test/model/TestSuiteDefTest.java
@@ -42,7 +42,7 @@ class TestSuiteDefTest {
 
     private static final String TEST_CASE_YAML =
             "name: test one\n"
-                    + "   description: test description\n"
+                    + "   notes: test description\n"
                     + "   expectations:\n"
                     + "    - an_expectation\n";
 
@@ -63,19 +63,19 @@ class TestSuiteDefTest {
                 .addEqualityGroup(
                         testSuite(
                                 "name",
-                                Optional.of("description"),
+                                Optional.of("notes"),
                                 Optional.of(disabled),
                                 List.of("service"),
                                 List.of(testCase)),
                         testSuite(
                                 "name",
-                                Optional.of("description"),
+                                Optional.of("notes"),
                                 Optional.of(disabled),
                                 List.of("service"),
                                 List.of(testCase)),
                         testSuite(
                                         "name",
-                                        Optional.of("description"),
+                                        Optional.of("notes"),
                                         Optional.of(disabled),
                                         List.of("service"),
                                         List.of(testCase))
@@ -83,7 +83,7 @@ class TestSuiteDefTest {
                 .addEqualityGroup(
                         testSuite(
                                 "diff",
-                                Optional.of("description"),
+                                Optional.of("notes"),
                                 Optional.of(disabled),
                                 List.of("service"),
                                 List.of(testCase)))
@@ -97,21 +97,21 @@ class TestSuiteDefTest {
                 .addEqualityGroup(
                         testSuite(
                                 "name",
-                                Optional.of("description"),
+                                Optional.of("notes"),
                                 Optional.of(disabled),
                                 List.of("diff"),
                                 List.of(testCase)))
                 .addEqualityGroup(
                         testSuite(
                                 "name",
-                                Optional.of("description"),
+                                Optional.of("notes"),
                                 Optional.empty(),
                                 List.of("service"),
                                 List.of(testCase)))
                 .addEqualityGroup(
                         testSuite(
                                 "name",
-                                Optional.of("description"),
+                                Optional.of("notes"),
                                 Optional.of(disabled),
                                 List.of("service"),
                                 List.of(testCase, testCase)))
@@ -124,7 +124,7 @@ class TestSuiteDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test suite\n"
-                        + "description: suite description\n"
+                        + "notes: suite description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "services:\n"
@@ -138,7 +138,7 @@ class TestSuiteDefTest {
 
         // Then:
         assertThat(result.name(), is("a test suite"));
-        assertThat(result.description(), is("suite description"));
+        assertThat(result.notes(), is("suite description"));
         assertThat(result.disabled().map(Disabled::reason), is(Optional.of("disabled reason")));
         assertThat(result.location(), is(UNKNOWN_LOCATION));
         assertThat(result.services(), contains("a_service"));
@@ -150,7 +150,7 @@ class TestSuiteDefTest {
         // Given:
         final String yaml =
                 "---\n"
-                        + "description: suite description\n"
+                        + "notes: suite description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "services:\n"
@@ -184,7 +184,7 @@ class TestSuiteDefTest {
         final TestSuiteDef result = parse(yaml);
 
         // Then:
-        assertThat(result.description(), is(""));
+        assertThat(result.notes(), is(""));
     }
 
     @Test
@@ -193,7 +193,7 @@ class TestSuiteDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test suite\n"
-                        + "description: suite description\n"
+                        + "notes: suite description\n"
                         + "services:\n"
                         + " - a_service\n"
                         + "tests:\n"
@@ -213,7 +213,7 @@ class TestSuiteDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test suite\n"
-                        + "description: suite description\n"
+                        + "notes: suite description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "tests:\n"
@@ -233,7 +233,7 @@ class TestSuiteDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test suite\n"
-                        + "description: suite description\n"
+                        + "notes: suite description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "services: []\n"
@@ -254,7 +254,7 @@ class TestSuiteDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test suite\n"
-                        + "description: suite description\n"
+                        + "notes: suite description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "services:\n"
@@ -273,7 +273,7 @@ class TestSuiteDefTest {
         final String yaml =
                 "---\n"
                         + "name: a test suite\n"
-                        + "description: suite description\n"
+                        + "notes: suite description\n"
                         + "disabled:\n"
                         + "  reason: disabled reason\n"
                         + "services:\n"

--- a/parser/src/main/java/org/creekservice/api/system/test/parser/TestPackagesLoader.java
+++ b/parser/src/main/java/org/creekservice/api/system/test/parser/TestPackagesLoader.java
@@ -55,8 +55,9 @@ public final class TestPackagesLoader {
             final Predicate<Path> predicate,
             final WalkerFactory walkerFactory) {
         this.rootDir = requireNonNull(rootDir, "rootDir");
-        this.parser = path -> requireNonNull(parser, "parser").parse(path, predicate);
+        this.parser = path -> parser.parse(path, predicate);
         this.walkerFactory = requireNonNull(walkerFactory, "walkerFactory");
+        requireNonNull(parser, "parser");
     }
 
     /**


### PR DESCRIPTION
part of https://github.com/creek-service/creek-kafka/issues/125

The Kafka test extension needs to set options before initializing the client extension.

Also fix a bug where `InitializeResourcesListener` was being called to early: before test extensions had a chance to start things up.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended