### PR TITLE
Add an error at the suite level to capture start up issues

### DIFF
--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/TestPackagesExecutor.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/TestPackagesExecutor.java
@@ -20,12 +20,14 @@ import static java.util.Objects.requireNonNull;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.creekservice.api.system.test.extension.test.model.TestExecutionResult;
 import org.creekservice.api.system.test.model.TestPackage;
 import org.creekservice.api.system.test.parser.TestPackagesLoader;
 import org.creekservice.internal.system.test.executor.result.ExecutionResult;
 import org.creekservice.internal.system.test.executor.result.ResultsWriter;
+import org.creekservice.internal.system.test.executor.result.SuiteResult;
 
 public final class TestPackagesExecutor {
 
@@ -53,12 +55,12 @@ public final class TestPackagesExecutor {
     @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     private TestExecutionResult executePackages() {
         try (Stream<TestPackage> packages = loader.stream()) {
-            return packages.map(TestPackage::suites)
-                    .flatMap(List::stream)
-                    .map(suiteExecutor::executeSuite)
-                    .map(List::of)
-                    .map(ExecutionResult::new)
-                    .reduce(new ExecutionResult(List.of()), ExecutionResult::combine);
+            final List<SuiteResult> result =
+                    packages.map(TestPackage::suites)
+                            .flatMap(List::stream)
+                            .map(suiteExecutor::executeSuite)
+                            .collect(Collectors.toList());
+            return new ExecutionResult(result);
         }
     }
 }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/TestSuiteExecutor.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/TestSuiteExecutor.java
@@ -17,7 +17,6 @@
 package org.creekservice.internal.system.test.executor.execution;
 
 import static java.util.Objects.requireNonNull;
-import static org.creekservice.internal.system.test.executor.result.CaseResult.testCaseResult;
 import static org.creekservice.internal.system.test.executor.result.SuiteResult.testSuiteResult;
 
 import java.time.Duration;
@@ -73,20 +72,7 @@ public final class TestSuiteExecutor {
             final SuiteExecutionFailedException cause =
                     new SuiteExecutionFailedException("Suite setup", testSuite, e);
 
-            testSuite.tests().stream()
-                    .map(
-                            test ->
-                                    test.disabled()
-                                            ? testCaseResult(test).disabled()
-                                            : testCaseResult(test).error(cause))
-                    .peek(
-                            result ->
-                                    listeners.forEach(
-                                            listener ->
-                                                    listener.afterTest(result.testCase(), result)))
-                    .forEach(builder::add);
-
-            return builder.build();
+            return builder.buildError(cause);
         }
 
         runSuite(testSuite, builder);

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/observation/LoggingTestEnvironmentListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/observation/LoggingTestEnvironmentListener.java
@@ -49,6 +49,18 @@ public final class LoggingTestEnvironmentListener implements TestEnvironmentList
 
     @Override
     public void afterSuite(final CreekTestSuite suite, final TestSuiteResult result) {
+        if (result.error().isPresent()) {
+            final Exception cause = result.error().get();
+            logger.info(
+                    "Start up failed for suite '"
+                            + suite.name()
+                            + "': "
+                            + cause.getMessage()
+                            + System.lineSeparator()
+                            + Throwables.stackTrace(cause));
+            return;
+        }
+
         final String skipped = result.skipped() == 0 ? "" : " skipped: " + result.skipped();
         final String errors = result.errors() == 0 ? "" : " errors: " + result.errors();
         final String failures = result.failures() == 0 ? "" : " failures: " + result.failures();

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/result/ExecutionResult.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/result/ExecutionResult.java
@@ -19,7 +19,6 @@ package org.creekservice.internal.system.test.executor.result;
 import static java.lang.System.lineSeparator;
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.creekservice.api.system.test.extension.test.model.TestExecutionResult;
@@ -44,7 +43,7 @@ public final class ExecutionResult implements TestExecutionResult {
 
     @Override
     public long errors() {
-        return results.stream().mapToLong(SuiteResult::errors).sum();
+        return results.stream().mapToLong(this::suiteErrors).sum();
     }
 
     @Override
@@ -57,12 +56,6 @@ public final class ExecutionResult implements TestExecutionResult {
         return List.copyOf(results);
     }
 
-    public ExecutionResult combine(final ExecutionResult with) {
-        final List<SuiteResult> all = new ArrayList<>(results);
-        all.addAll(with.results);
-        return new ExecutionResult(all);
-    }
-
     @Override
     public String toString() {
         return "ExecutionResult{results="
@@ -72,5 +65,9 @@ public final class ExecutionResult implements TestExecutionResult {
                         .collect(Collectors.joining("," + lineSeparator()))
                 + lineSeparator()
                 + "}";
+    }
+
+    private long suiteErrors(final SuiteResult result) {
+        return result.errors() + result.error().stream().mapToLong(e -> 1L).sum();
     }
 }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/result/xml/XmlIssue.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/result/xml/XmlIssue.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.result.xml;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
+import org.creekservice.api.base.type.Throwables;
+
+public final class XmlIssue {
+
+    private final Throwable cause;
+
+    XmlIssue(final Throwable cause) {
+        this.cause = requireNonNull(cause, "cause");
+    }
+
+    @JacksonXmlProperty(isAttribute = true)
+    @JsonGetter("message")
+    public String message() {
+        return requireNonNullElse(cause.getMessage(), "");
+    }
+
+    @JacksonXmlProperty(isAttribute = true)
+    @JsonGetter("type")
+    public String type() {
+        return cause.getClass().getCanonicalName();
+    }
+
+    @JacksonXmlText
+    @JsonGetter("stack")
+    public String stack() {
+        return Throwables.stackTrace(cause);
+    }
+}

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/result/xml/XmlTestCaseResult.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/result/xml/XmlTestCaseResult.java
@@ -17,16 +17,12 @@
 package org.creekservice.internal.system.test.executor.result.xml;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.Objects.requireNonNullElse;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import org.creekservice.api.base.type.Throwables;
 import org.creekservice.api.system.test.extension.test.model.TestCaseResult;
 
 /** Test case result that can be serialized as part of JUnit style test XML report. */
@@ -63,45 +59,18 @@ public final class XmlTestCaseResult {
     }
 
     @JacksonXmlProperty
-    public Optional<Issue> failure() {
-        return result.failure().map(Issue::new);
+    public Optional<XmlIssue> failure() {
+        return result.failure().map(XmlIssue::new);
     }
 
     @JacksonXmlProperty
-    public Optional<Issue> error() {
-        return result.error().map(Issue::new);
+    public Optional<XmlIssue> error() {
+        return result.error().map(XmlIssue::new);
     }
 
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
     @JacksonXmlProperty
     public Optional<Object> skipped() {
         return result.skipped() ? Optional.of(new Object()) : Optional.empty();
-    }
-
-    public static final class Issue {
-
-        private final Throwable cause;
-
-        public Issue(final Throwable cause) {
-            this.cause = requireNonNull(cause, "cause");
-        }
-
-        @JacksonXmlProperty(isAttribute = true)
-        @JsonGetter("message")
-        public String message() {
-            return requireNonNullElse(cause.getMessage(), "");
-        }
-
-        @JacksonXmlProperty(isAttribute = true)
-        @JsonGetter("type")
-        public String type() {
-            return cause.getClass().getCanonicalName();
-        }
-
-        @JacksonXmlText
-        @JsonGetter("stack")
-        public String stack() {
-            return Throwables.stackTrace(cause);
-        }
     }
 }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/result/xml/XmlTestSuiteResult.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/result/xml/XmlTestSuiteResult.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.system.test.extension.test.model.TestSuiteResult;
@@ -56,7 +57,7 @@ public final class XmlTestSuiteResult {
 
     @JacksonXmlProperty(isAttribute = true)
     public long tests() {
-        return result.testCases().size();
+        return result.testResults().size();
     }
 
     @JacksonXmlProperty(isAttribute = true)
@@ -72,6 +73,11 @@ public final class XmlTestSuiteResult {
     @JacksonXmlProperty(isAttribute = true)
     public long errors() {
         return result.errors();
+    }
+
+    @JacksonXmlProperty
+    public Optional<XmlIssue> error() {
+        return result.error().map(XmlIssue::new);
     }
 
     @JacksonXmlProperty(isAttribute = true)
@@ -95,7 +101,7 @@ public final class XmlTestSuiteResult {
 
     @JacksonXmlProperty
     public List<XmlTestCaseResult> testcase() {
-        return result.testCases().stream().map(XmlTestCaseResult::from).collect(toList());
+        return result.testResults().stream().map(XmlTestCaseResult::from).collect(toList());
     }
 
     private static String localHostName() {

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/TestSuiteExecutorTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/TestSuiteExecutorTest.java
@@ -17,6 +17,7 @@
 package org.creekservice.internal.system.test.executor.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
@@ -24,7 +25,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -158,23 +158,11 @@ class TestSuiteExecutorTest {
         final SuiteResult result = suiteExecutor.executeSuite(testSuite);
 
         // Then:
-        assertThat(result.errors(), is(1L));
-        assertThat(result.skipped(), is(1L));
-        final CaseResult result0 = result.testCases().get(0);
+        assertThat(result.errors(), is(2L));
+        assertThat(result.testResults(), is(empty()));
         assertThat(
-                result0.error().map(Exception::getMessage),
+                result.error().map(Exception::getMessage),
                 is(Optional.of("Suite setup failed for test suite: Fred, cause: boom")));
-        assertThat(result0.error().map(Exception::getCause), is(Optional.of(cause)));
-        assertThat(result0.skipped(), is(false));
-        final CaseResult result1 = result.testCases().get(1);
-        assertThat(result1.error(), is(Optional.empty()));
-        assertThat(result1.skipped(), is(true));
-
-        verify(listeners, times(3)).forEach(actionCaptor.capture());
-        actionCaptor.getAllValues().get(1).accept(listener);
-        verify(listener).afterTest(testCase0, result0);
-        actionCaptor.getAllValues().get(2).accept(listener);
-        verify(listener).afterTest(testCase1, result1);
 
         assertAfterTestCalled(result);
     }
@@ -192,15 +180,11 @@ class TestSuiteExecutorTest {
 
         // Then:
         assertThat(result.errors(), is(1L));
-        final CaseResult result0 = result.testCases().get(0);
+        assertThat(result.testResults(), is(empty()));
         assertThat(
-                result0.error().map(Exception::getMessage),
+                result.error().map(Exception::getMessage),
                 is(Optional.of("Suite setup failed for test suite: Fred, cause: boom")));
-        assertThat(result0.error().map(Exception::getCause), is(Optional.of(cause)));
-
-        verify(listeners, times(2)).forEach(actionCaptor.capture());
-        actionCaptor.getAllValues().get(1).accept(listener);
-        verify(listener).afterTest(testCase0, result0);
+        assertThat(result.error().map(Exception::getCause), is(Optional.of(cause)));
 
         assertAfterTestCalled(result);
     }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/observation/LoggingTestEnvironmentListenerTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/observation/LoggingTestEnvironmentListenerTest.java
@@ -150,4 +150,19 @@ class LoggingTestEnvironmentListenerTest {
         // Then:
         verify(logger).info("Finished suite 'Bob' skipped: 1 errors: 2 failures: 3");
     }
+
+    @Test
+    void shouldLogAfterSuiteStartUpFailure() {
+        // Given:
+        when(suite.name()).thenReturn("Bob");
+        final RuntimeException cause = new RuntimeException("msg");
+        when(suiteResult.error()).thenReturn(Optional.of(cause));
+
+        // When:
+        listener.afterSuite(suite, suiteResult);
+
+        // Then:
+        verify(logger)
+                .info("Start up failed for suite 'Bob': msg\n" + Throwables.stackTrace(cause));
+    }
 }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/result/ExecutionResultTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/result/ExecutionResultTest.java
@@ -18,11 +18,11 @@ package org.creekservice.internal.system.test.executor.result;
 
 import static java.lang.System.lineSeparator;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,19 +62,6 @@ class ExecutionResultTest {
     }
 
     @Test
-    void shouldCombine() {
-        // Given:
-        final ExecutionResult result2 = new ExecutionResult(List.of(suiteResult1));
-
-        // When:
-        final ExecutionResult combined =
-                new ExecutionResult(List.of(suiteResult0)).combine(result2);
-
-        // Then:
-        assertThat(combined.results(), contains(suiteResult0, suiteResult1));
-    }
-
-    @Test
     void shouldCountFailures() {
         // Given:
         when(suiteResult0.failures()).thenReturn(1L);
@@ -87,7 +74,7 @@ class ExecutionResultTest {
     @Test
     void shouldCountErrors() {
         // Given:
-        when(suiteResult0.errors()).thenReturn(1L);
+        when(suiteResult0.error()).thenReturn(Optional.of(new RuntimeException()));
         when(suiteResult1.errors()).thenReturn(2L);
 
         // Then:

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/result/SuiteResultTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/result/SuiteResultTest.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import org.creekservice.api.system.test.model.TestCase;
 import org.creekservice.api.system.test.model.TestSuite;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,7 +67,7 @@ class SuiteResultTest {
         assertThat(result.errors(), is(0L));
         assertThat(result.start(), is(START));
         assertThat(result.duration(), is(DURATION));
-        assertThat(result.testCases(), is(empty()));
+        assertThat(result.testResults(), is(empty()));
     }
 
     @Test
@@ -84,7 +85,7 @@ class SuiteResultTest {
         assertThat(result.errors(), is(0L));
         assertThat(result.start(), is(START));
         assertThat(result.duration(), is(DURATION));
-        assertThat(result.testCases(), contains(disabled, disabled));
+        assertThat(result.testResults(), contains(disabled, disabled));
     }
 
     @Test
@@ -102,7 +103,7 @@ class SuiteResultTest {
         assertThat(result.errors(), is(0L));
         assertThat(result.start(), is(START));
         assertThat(result.duration(), is(DURATION));
-        assertThat(result.testCases(), contains(success, success));
+        assertThat(result.testResults(), contains(success, success));
     }
 
     @Test
@@ -120,7 +121,7 @@ class SuiteResultTest {
         assertThat(result.errors(), is(0L));
         assertThat(result.start(), is(START));
         assertThat(result.duration(), is(DURATION));
-        assertThat(result.testCases(), contains(failure, failure));
+        assertThat(result.testResults(), contains(failure, failure));
     }
 
     @Test
@@ -138,7 +139,26 @@ class SuiteResultTest {
         assertThat(result.errors(), is(2L));
         assertThat(result.start(), is(START));
         assertThat(result.duration(), is(DURATION));
-        assertThat(result.testCases(), contains(error, error));
+        assertThat(result.testResults(), contains(error, error));
+    }
+
+    @Test
+    void shouldBuildWithSuiteError() {
+        // Given:
+        final RuntimeException cause = new RuntimeException();
+        when(testSuite.tests()).thenReturn(List.of(testCase, testCase));
+
+        // When:
+        final SuiteResult result = builder.buildError(cause);
+
+        // Then:
+        assertThat(result.testSuite(), is(testSuite));
+        assertThat(result.skipped(), is(0L));
+        assertThat(result.failures(), is(0L));
+        assertThat(result.errors(), is(2L));
+        assertThat(result.start(), is(START));
+        assertThat(result.duration(), is(DURATION));
+        assertThat(result.testResults(), is(empty()));
     }
 
     @Test
@@ -162,8 +182,32 @@ class SuiteResultTest {
                                 + "location=loc:///suite-1, "
                                 + "start=2022-10-08T17:16:41.600Z, "
                                 + "finish=2022-10-08T17:17:24.499Z, "
+                                + "error=<none>, "
                                 + "tests=["
                                 + success
                                 + "]}"));
+    }
+
+    @Test
+    void shouldToStringSuiteError() {
+        // Given:
+        final Exception cause = new RuntimeException("boom");
+        when(testSuite.name()).thenReturn("suite-1");
+        when(testSuite.location()).thenReturn(URI.create("loc:///suite-1"));
+
+        // When:
+        final SuiteResult result = builder.buildError(cause);
+
+        // Then:
+        assertThat(
+                result.toString(),
+                is(
+                        "SuiteResult{"
+                                + "name=suite-1, "
+                                + "location=loc:///suite-1, "
+                                + "start=2022-10-08T17:16:41.600Z, "
+                                + "finish=2022-10-08T17:17:24.499Z, "
+                                + "error=boom, "
+                                + "tests=[]}"));
     }
 }

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/test/model/TestSuiteResult.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/test/model/TestSuiteResult.java
@@ -20,6 +20,7 @@ package org.creekservice.api.system.test.extension.test.model;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 public interface TestSuiteResult {
 
@@ -41,6 +42,13 @@ public interface TestSuiteResult {
     /** @return how long the test suite took to run. */
     Duration duration();
 
+    /**
+     * Indicates the test suite did not execute.
+     *
+     * @return any exception thrown trying to set up the suite.
+     */
+    Optional<Exception> error();
+
     /** @return the results for the tests within the suite. */
-    List<? extends TestCaseResult> testCases();
+    List<? extends TestCaseResult> testResults();
 }

--- a/parser/README.md
+++ b/parser/README.md
@@ -38,5 +38,3 @@ class ExampleTestParsing {
     }
 }
 ```
-
-// Todo: does this even work?


### PR DESCRIPTION
This makes for a cleaner `SuiteResult.toString()` and Junit style xml result file, as the error is only listed once.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended