### PR TITLE
Discover Jackson modules

### DIFF
--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/expectation/Verifiers.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/expectation/Verifiers.java
@@ -77,6 +77,7 @@ public final class Verifiers {
             this.suite = requireNonNull(suite, "suite");
         }
 
+        /** @return the default timeout to use when verifying expectations. */
         @Override
         public Duration timeout() {
             return verifierTimeout;

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/result/xml/XmlResultsWriterTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/result/xml/XmlResultsWriterTest.java
@@ -133,6 +133,20 @@ class XmlResultsWriterTest {
     }
 
     @Test
+    void shouldOverwriteExistingFiles() {
+        // Given:
+        TestPaths.write(outputDir.resolve("TEST-suite0.xml"), "old results");
+        TestPaths.write(outputDir.resolve("TEST-suite1.xml"), "old results");
+
+        // When:
+        writer.write(result);
+
+        // Then:
+        assertThat(outputDir.resolve("TEST-suite0.xml"), fileContains("some xml"));
+        assertThat(outputDir.resolve("TEST-suite1.xml"), fileContains("some more xml"));
+    }
+
+    @Test
     void shouldSanitizeSuiteNameForUseInFileName() {
         // Given:
         when(suite0.testSuite().name()).thenReturn("!some $$ Weird --___ !£$%£^&* Name");

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/test/model/ExpectationHandler.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/test/model/ExpectationHandler.java
@@ -55,7 +55,14 @@ public interface ExpectationHandler<T extends Expectation> {
 
     interface ExpectationOptions {
 
-        /** @return the timeout to use when verifying expectations */
+        /**
+         * The default timeout to use when verifying expectations
+         *
+         * <p>Test extensions may choose to provide a way for the user to override this default,
+         * i.e. via an {@link Option option extensions}
+         *
+         * @return the default timeout to use when verifying expectations
+         */
         Duration timeout();
 
         /**

--- a/parser/src/main/java/org/creekservice/internal/system/test/parser/SystemTestMapper.java
+++ b/parser/src/main/java/org/creekservice/internal/system/test/parser/SystemTestMapper.java
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import java.util.Collection;
 import org.creekservice.api.system.test.extension.test.model.Expectation;
 import org.creekservice.api.system.test.extension.test.model.ExpectationRef;
@@ -55,7 +54,7 @@ public final class SystemTestMapper {
                 JsonMapper.builder(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES))
                         .disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)
                         .addModule(modelModule)
-                        .addModule(new Jdk8Module())
+                        .findAndAddModules()
                         .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                         .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
                         .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)


### PR DESCRIPTION
Switch to using `JsonMapper.Builder.findAndAddModules()` to allow test extensions to add other modules they need to the `SystemTestMapper`.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended