### PR TITLE
Prefix container logging with service instance name

### DIFF
--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/DockerServiceContainer.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/DockerServiceContainer.java
@@ -165,7 +165,7 @@ public final class DockerServiceContainer implements ServiceInstanceContainer {
         container
                 .withNetwork(network)
                 .withNetworkAliases(instanceName)
-                .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(instanceName)));
+                .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(instanceName)).withPrefix(instanceName));
 
         return container;
     }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/DockerServiceContainer.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/DockerServiceContainer.java
@@ -165,7 +165,9 @@ public final class DockerServiceContainer implements ServiceInstanceContainer {
         container
                 .withNetwork(network)
                 .withNetworkAliases(instanceName)
-                .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(instanceName)).withPrefix(instanceName));
+                .withLogConsumer(
+                        new Slf4jLogConsumer(LoggerFactory.getLogger(instanceName))
+                                .withPrefix(instanceName));
 
         return container;
     }


### PR DESCRIPTION
To make it easier to interpret system test logs, prefix each log line logged by a docker container with the name of the service instance running in the container.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure correct labels applied
- [ ] Ensure any appropriate documentation has been added or amended