### PR TITLE
Graceful shutdown of Docker containers

### DIFF
--- a/extension/src/main/java/org/creekservice/api/system/test/extension/test/env/suite/service/ConfigurableServiceInstance.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/test/env/suite/service/ConfigurableServiceInstance.java
@@ -82,7 +82,18 @@ public interface ConfigurableServiceInstance extends ServiceInstance {
     ConfigurableServiceInstance setStartupLogMessage(String regex, int times);
 
     /**
-     * Set a startup timeout after which the instance will be considered failed.
+     * Set how many attempts should be made to start the instance.
+     *
+     * <p>If the max attempts is exceeded the test suite will fail.
+     *
+     * @param attempts the max attempts.
+     * @return self, for method chaining.
+     * @throws IllegalStateException if the instance is running.
+     */
+    ConfigurableServiceInstance setStartupAttempts(int attempts);
+
+    /**
+     * Set a startup timeout, after which the instance will be considered failed.
      *
      * <p>Failed containers may result in another attempt, or cause the test suite to fail.
      *
@@ -93,13 +104,14 @@ public interface ConfigurableServiceInstance extends ServiceInstance {
     ConfigurableServiceInstance setStartupTimeout(Duration timeout);
 
     /**
-     * Set how many attempts should be made to start the instance.
+     * Set a shutdown timeout, after which the instance will be killed.
      *
-     * <p>If the max attempts is exceeded the test suite will fail.
+     * <p>Containers are first sent a SIGTERM signal, which should trigger a graceful shutdown. If
+     * the container fails to stop within the configured timeout it will be sent a SIGKILL signal.
      *
-     * @param attempts the max attempts.
+     * @param timeout the timeout
      * @return self, for method chaining.
      * @throws IllegalStateException if the instance is running.
      */
-    ConfigurableServiceInstance setStartupAttempts(int attempts);
+    ConfigurableServiceInstance setShutdownTimeout(Duration timeout);
 }

--- a/test-util/src/test/java/org/creekservice/api/system/test/test/util/CreekSystemTestExtensionTesterTest.java
+++ b/test-util/src/test/java/org/creekservice/api/system/test/test/util/CreekSystemTestExtensionTesterTest.java
@@ -143,6 +143,7 @@ class CreekSystemTestExtensionTesterTest {
         assertThat(services.iterator().hasNext(), is(false));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void shouldDefaultToNoServicesBeingDebug() {
         assertThat(
@@ -150,6 +151,7 @@ class CreekSystemTestExtensionTesterTest {
                 is(ServiceDebugInfo.none()));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void shouldSupportConfiguringServiceDebugInfo() {
         // Given:
@@ -163,6 +165,7 @@ class CreekSystemTestExtensionTesterTest {
                 is(debugServiceInfo));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void shouldSupportConfiguringServicesForDebugging() {
         // Given:


### PR DESCRIPTION
part of: https://github.com/creek-service/creek-system-test/issues/172

Turns out TestContainers kills containers, rather than asking them nicely to stop. This causes issues with test coverage reporting as the JaCoCo agent only reports coverage on application exit. Enhance the code to first attempt a graceful shutdown, before falling back to a kill for stubborn services.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure correct labels applied
- [ ] Ensure any appropriate documentation has been added or amended