### PR TITLE
Parse multiple mounts correctly

### DIFF
--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerFactory.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerFactory.java
@@ -114,7 +114,7 @@ public final class ContainerFactory implements TestEnvironmentListener {
                         : regularFactory.create(imageName);
 
         if (serviceUnderTest || serviceDebugPort.isPresent()) {
-            configureServiceUnderTest(container, serviceDebugPort);
+            configureServiceUnderTest(instanceName, container, serviceDebugPort);
         }
 
         container
@@ -151,17 +151,20 @@ public final class ContainerFactory implements TestEnvironmentListener {
     }
 
     private void configureServiceUnderTest(
-            final GenericContainer<?> container, final Optional<Integer> serviceDebugPort) {
+            final String instanceName, final GenericContainer<?> container, final Optional<Integer> serviceDebugPort) {
         final Map<String, String> configuredEnv = configuredEnv(serviceDebugPort);
         if (!configuredEnv.isEmpty()) {
-            LOGGER.debug("Setting container env. env: " + configuredEnv);
+            LOGGER.info("Setting container env. instance: "
+                    + instanceName + ", env : " + configuredEnv);
             container.withEnv(configuredEnv);
         }
 
         mountInfo.forEach(
                 mount -> {
-                    LOGGER.debug(
-                            "Adding container mount. hostPath "
+                    LOGGER.info(
+                            "Adding container mount. instance: "
+                                    + instanceName
+                                    + ". hostPath "
                                     + mount.hostPath()
                                     + ", containerPath: "
                                     + mount.containerPath()

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
@@ -310,6 +310,24 @@ class PicoCliParserTest {
     }
 
     @Test
+    void shouldParseMultipleMounts() {
+        // Given:
+        final String[] args =
+                minimalArgs(
+                        "--mount-read-only=/host/path=/container/path",
+                        "--mount-read-only=/host/path2=/container/path2",
+                        "--mount-writable=host/path=container/path",
+                        "--mount-writable=host/path2=container/path2");
+
+        // When:
+        final Optional<ExecutorOptions> result = parse(args);
+
+        // Then:
+        assertThat(
+                result.map(ExecutorOptions::mountInfo).map(Collection::size), is(Optional.of(4)));
+    }
+
+    @Test
     void shouldThrowOnReadOnlyMountWithEmptyHostPath() {
         // Given:
         final String[] args = minimalArgs("--mount-read-only==container/path");


### PR DESCRIPTION
Part of: https://github.com/creek-service/creek-system-test/issues/172

...initial drop was adding, rather than setting, mounts. If there are two mounts Picocli calls the method with 0, 1 then 2 entries in the map.  If adding, the result is a list of 3 mounts, with the first one duplicated.  Code needs to set the list.

### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
