### PR TITLE
Ensure Docker container logs are captured on error

### DIFF
--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -20,6 +20,7 @@
  * <p>Apply to all java modules, usually excluding the root project in multi-module sets.
  *
  * <p>Version: 1.5
+ *  - 1.6: Remove GitHub packages for snapshots
  *  - 1.5: Add filters to exclude generated sources
  *  - 1.4: Add findsecbugs-plugin
  *  - 1.3: Fail on warnings for test code too.
@@ -42,7 +43,6 @@ java {
 repositories {
     mavenCentral()
 
-    // Primary snapshot repo:
     maven {
         url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
         mavenContent {
@@ -50,21 +50,6 @@ repositories {
             snapshotsOnly()
         }
     }
-
-    // Backup snapshot repo:
-    maven {
-        url = uri("https://maven.pkg.github.com/creek-service/*")
-        credentials {
-            username = System.getenv("GITHUB_ACTOR")
-            password = System.getenv("GITHUB_TOKEN")
-        }
-        mavenContent {
-            includeGroup("org.creekservice")
-            snapshotsOnly()
-        }
-    }
-
-    mavenCentral()
 }
 
 dependencies {

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstance.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstance.java
@@ -123,8 +123,9 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
                     imageName,
                     container.getContainerId());
         } catch (final Exception e) {
+            final String logs = container.getLogs();
             stop();
-            throw new FailedToStartServiceException(name, imageName, container, e);
+            throw new FailedToStartServiceException(name, imageName, logs, e);
         }
     }
 
@@ -343,7 +344,7 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
         FailedToStartServiceException(
                 final String name,
                 final DockerImageName imageName,
-                final GenericContainer<?> container,
+                final String logs,
                 final Throwable cause) {
             super(
                     "Failed to start service: "
@@ -355,7 +356,7 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
                             + cause.getMessage()
                             + lineSeparator()
                             + "Logs: "
-                            + container.getLogs(),
+                            + logs,
                     cause);
         }
     }

--- a/test-service/src/main/java/org/creekservice/internal/system/test/test/service/ServiceMain.java
+++ b/test-service/src/main/java/org/creekservice/internal/system/test/test/service/ServiceMain.java
@@ -32,6 +32,7 @@ public final class ServiceMain {
 
     public static void main(final String... args) {
         dumpEnv();
+        maybeFail();
         logMount();
         doLogging();
         awaitShutdown();
@@ -41,6 +42,13 @@ public final class ServiceMain {
         System.getenv().entrySet().stream()
                 .filter(e -> e.getKey().startsWith("CREEK_"))
                 .forEach(e -> LOGGER.info("Env: " + e.getKey() + "=" + e.getValue()));
+    }
+
+    private static void maybeFail() {
+        if (System.getenv("CREEK_SERVICE_SHOULD_FAIL") != null) {
+            LOGGER.error("CREEK_SERVICE_SHOULD_FAIL is set, so this service is going bye-byes!");
+            throw new RuntimeException("Service going BOOM!");
+        }
     }
 
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")


### PR DESCRIPTION
If a Docker containers fails to start, the logs were not getting picked up correctly. With this fix the logs are grabbed _before_ the container is stopped, which loses the logs.

Tests added to ensure this works as expected.

### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/creek-service/.github/blob/main/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
