### PR TITLE
Support debug-only env

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ subprojects {
         set("spotBugsVersion", "4.7.3")         // https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-annotations
         set("jacksonVersion", "2.14.2")         // https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations
         set("picocliVersion", "4.7.1")          // https://mvnrepository.com/artifact/info.picocli/picocli
-        set("log4jVersion", "2.19.0")           // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
+        set("log4jVersion", "2.20.0")           // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
         set("slf4jVersion", "2.0.6")           // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
 
         set("guavaVersion", "31.1-jre")         // https://mvnrepository.com/artifact/com.google.guava/guava

--- a/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
@@ -17,7 +17,8 @@
 /**
  * Configuration for Creek Gradle plugin publishing.
  *
- * <p>Version: 1.3
+ * <p>Version: 1.4
+ *  - 1.4: Fix website URL to avoid redirect 
  *  - 1.3: Switch to setting 'system' from issue-management
  *
  * <p>Apply this plugin to any module publishing a Gradle plugin.
@@ -41,7 +42,7 @@ java {
 val prependRootName = rootProject.name != project.name
 
 pluginBundle {
-    website = "https://www.creekservice.org/${rootProject.name}"
+    website = "https://www.creekservice.org/${rootProject.name}/"
     vcsUrl = "https://github.com/creek-service/${rootProject.name}"
 
     tags = listOf("creek", "creekservice")

--- a/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
@@ -17,7 +17,8 @@
 /**
  * Standard configuration for Creek library publishing
  *
- * <p>Version: 1.3
+ * <p>Version: 1.4
+ *  - 1.4: Fix website URL to avoid redirect
  *  - 1.3: Switch to setting 'system' from issue-management
  *
  * <p> Apply this plugin only to subprojects if in multi-module setup.

--- a/executor/src/main/java/org/creekservice/api/system/test/executor/ExecutorOptions.java
+++ b/executor/src/main/java/org/creekservice/api/system/test/executor/ExecutorOptions.java
@@ -71,12 +71,7 @@ public interface ExecutorOptions {
      * <p>In addition to providing this information, actually debugging a service requires the
      * caller to provide the actual debugging mechanism. This will generally involve providing a
      * {@link #mountInfo() mount} containing a Java agent, and enabling the agent by setting {@code
-     * JAVA_TOOLS_OPTIONS} environment variable via {@link #env()}.
-     *
-     * <p>When the {@code JAVA_TOOLS_OPTIONS} environment variable is set on a service being
-     * debugged, the test executor will search for the text {@code ${SERVICE_DEBUG_PORT}} in the
-     * variable's value and replace with the port number the Docker container is configured to
-     * expose to allow debugging.
+     * JAVA_TOOLS_OPTIONS} environment variable via {@link ServiceDebugInfo#env()}.
      *
      * @return info about which services should be debugged.
      */
@@ -94,14 +89,10 @@ public interface ExecutorOptions {
 
     /**
      * Provides an optional map of environment variables that will be set on each service-under-test
-     * instance or service-being-debugged.
+     * instance.
      *
      * <p>For example, this can be used to set the {@code JAVA_TOOLS_OPTIONS} required to enable
-     * coverage and/or service debugging.
-     *
-     * <p>When debugging services, the all instances of the text {@code ${SERVICE_DEBUG_PORT}} found
-     * in the {@code JAVA_TOOLS_OPTIONS} value, if present, will be replaced with the port the
-     * service is configured to listen for the debugger on.
+     * coverage metrics capture.
      *
      * @return map of environment variables to set on each service-under-test.
      */
@@ -153,6 +144,26 @@ public interface ExecutorOptions {
          * @return set of service instances to debug.
          */
         Set<String> serviceInstanceNames();
+
+        /**
+         * Provides an optional map of environment variables that will be set on each service being
+         * debugged.
+         *
+         * <p>Note: This will overwrite any environment variables with matching names in {@link
+         * ExecutorOptions#env()}. It is the callers responsibility to merge values, if required.
+         *
+         * <p>For example, this can be used to set the {@code JAVA_TOOLS_OPTIONS} required to enable
+         * service debugging.
+         *
+         * <p>When debugging services, all instances of the text {@code ${SERVICE_DEBUG_PORT}} found
+         * in the {@code JAVA_TOOLS_OPTIONS} value, if present, will be replaced with the port the
+         * service is configured to listen for the debugger on.
+         *
+         * @return map of environment variables to set on each service being debugged.
+         */
+        default Map<String, String> env() {
+            return Map.of();
+        }
     }
 
     /** Information about a single mount. */

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/cli/PicoCliParser.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/cli/PicoCliParser.java
@@ -194,6 +194,14 @@ public final class PicoCliParser {
         }
 
         @Option(
+                names = {"-de", "--debug-env"},
+                split = ",",
+                description =
+                        "Comma seperated list of key=value environment variables to set on each"
+                                + " service being debugged.")
+        private Map<String, String> debugEnv = Map.of();
+
+        @Option(
                 names = {"-e", "--env"},
                 split = ",",
                 description =
@@ -281,7 +289,8 @@ public final class PicoCliParser {
 
             return Optional.of(
                     org.creekservice.internal.system.test.executor.execution.debug.ServiceDebugInfo
-                            .serviceDebugInfo(debugServicePort, debugServices, debugInstances));
+                            .serviceDebugInfo(
+                                    debugServicePort, debugServices, debugInstances, debugEnv));
         }
 
         @Override

--- a/executor/src/test/java/org/creekservice/api/system/test/executor/ExecutorOptionsTest.java
+++ b/executor/src/test/java/org/creekservice/api/system/test/executor/ExecutorOptionsTest.java
@@ -97,4 +97,9 @@ class ExecutorOptionsTest {
     void shouldDefaultToNoEnv() {
         assertThat(options.env(), is(Map.of()));
     }
+
+    @Test
+    void shouldDefaultToNoDebugEnv() {
+        assertThat(debugInfo.env(), is(Map.of()));
+    }
 }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/DockerServiceContainerFunctionalTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/DockerServiceContainerFunctionalTest.java
@@ -70,6 +70,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.quality.Strictness;
@@ -331,8 +333,9 @@ class DockerServiceContainerFunctionalTest {
     }
 
     @SuppressWarnings("ConstantConditions")
-    @Test
-    void shouldSetEnvOnInstanceUnderTest() {
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest
+    void shouldSetEnvOnInstanceUnderTest(final boolean debug) {
         // Given:
         givenServiceUnderTest();
         instances =
@@ -341,6 +344,7 @@ class DockerServiceContainerFunctionalTest {
                                 serviceDebugInfo,
                                 List.of(),
                                 Map.of("CREEK_TEST_ENV_KEY", "expected value")));
+        when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(debug);
         final ServiceInstance instance = instances.add(serviceDef);
 
         // Then:
@@ -352,8 +356,9 @@ class DockerServiceContainerFunctionalTest {
     }
 
     @SuppressWarnings("ConstantConditions")
-    @Test
-    void shouldNotSetEnvOn3rdPartyInstance() {
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest
+    void shouldNotSetEnvOn3rdPartyInstance(final boolean debug) {
         // Given:
         instances =
                 new DockerServiceContainer(
@@ -361,6 +366,7 @@ class DockerServiceContainerFunctionalTest {
                                 serviceDebugInfo,
                                 List.of(),
                                 Map.of("CREEK_TEST_ENV_KEY", "expected value")));
+        when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(debug);
         final ServiceInstance instance = instances.add(serviceDef);
 
         // Then:
@@ -372,16 +378,21 @@ class DockerServiceContainerFunctionalTest {
     }
 
     @SuppressWarnings("ConstantConditions")
-    @Test
-    void shouldNotSetEnvOn3rdPartyInstanceUnlessDebuggingThem() {
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest
+    void shouldSetDebugEnvOnOnInstanceIfDebugging(final boolean serviceUnderTest) {
         // Given:
+        if (serviceUnderTest) {
+            givenServiceUnderTest();
+        }
         instances =
                 new DockerServiceContainer(
                         new ContainerFactory(
                                 serviceDebugInfo,
                                 List.of(),
-                                Map.of("CREEK_TEST_ENV_KEY", "expected value")));
+                                Map.of("CREEK_TEST_ENV_KEY", "original value")));
         when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(true);
+        when(serviceDebugInfo.env()).thenReturn(Map.of("CREEK_TEST_ENV_KEY", "expected value"));
         final ServiceInstance instance = instances.add(serviceDef);
 
         // Then:

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
@@ -274,6 +274,67 @@ class PicoCliParserTest {
     }
 
     @Test
+    void shouldParseSingleDebugEnv() {
+        // Given:
+        final String[] args = minimalArgs("--debug-env=NAME=VALUE", "--debug-service=a");
+
+        // When:
+        final Optional<ExecutorOptions> result = parse(args);
+
+        // Then:
+        assertThat(
+                result.flatMap(ExecutorOptions::serviceDebugInfo)
+                        .map(ExecutorOptions.ServiceDebugInfo::env),
+                is(Optional.of(Map.of("NAME", "VALUE"))));
+    }
+
+    @Test
+    void shouldParseSingleMultipleDebugEnvInSingleParam() {
+        // Given:
+        final String[] args = minimalArgs("--debug-env=NAME=VALUE,NAME2=V2", "--debug-service=a");
+
+        // When:
+        final Optional<ExecutorOptions> result = parse(args);
+
+        // Then:
+        assertThat(
+                result.flatMap(ExecutorOptions::serviceDebugInfo)
+                        .map(ExecutorOptions.ServiceDebugInfo::env),
+                is(Optional.of(Map.of("NAME", "VALUE", "NAME2", "V2"))));
+    }
+
+    @Test
+    void shouldParseDebugEnvWithSpaceInValue() {
+        // Given:
+        final String[] args = minimalArgs("--debug-env=NAME=\"VAL UE\"", "--debug-service=a");
+
+        // When:
+        final Optional<ExecutorOptions> result = parse(args);
+
+        // Then:
+        assertThat(
+                result.flatMap(ExecutorOptions::serviceDebugInfo)
+                        .map(ExecutorOptions.ServiceDebugInfo::env),
+                is(Optional.of(Map.of("NAME", "VAL UE"))));
+    }
+
+    @Test
+    void shouldParseSingleMultipleDebugEnvInMultipleParams() {
+        // Given:
+        final String[] args =
+                minimalArgs("--debug-env=NAME=VALUE", "-de=NAME2=V2", "--debug-service=a");
+
+        // When:
+        final Optional<ExecutorOptions> result = parse(args);
+
+        // Then:
+        assertThat(
+                result.flatMap(ExecutorOptions::serviceDebugInfo)
+                        .map(ExecutorOptions.ServiceDebugInfo::env),
+                is(Optional.of(Map.of("NAME", "VALUE", "NAME2", "V2"))));
+    }
+
+    @Test
     void shouldParseReadOnlyMount() {
         // Given:
         final String[] args = minimalArgs("--mount-read-only=/host/path=/container/path");

--- a/test-service/src/main/java/org/creekservice/internal/system/test/test/service/ServiceMain.java
+++ b/test-service/src/main/java/org/creekservice/internal/system/test/test/service/ServiceMain.java
@@ -82,13 +82,13 @@ public final class ServiceMain {
         LOGGER.info(BasicLifecycle.started.logMessage(BasicLifecycle.SERVICE_TYPE));
     }
 
-    @SuppressWarnings({"InfiniteLoopStatement", "BusyWait"})
+    @SuppressWarnings("BusyWait")
     private static void awaitShutdown() {
         while (true) {
             try {
-                Thread.sleep(1000);
+                Thread.sleep(100);
             } catch (InterruptedException e) {
-                // meh
+                return;
             }
         }
     }

--- a/test-util/src/main/java/org/creekservice/api/system/test/test/util/CreekSystemTestExtensionTester.java
+++ b/test-util/src/main/java/org/creekservice/api/system/test/test/util/CreekSystemTestExtensionTester.java
@@ -247,7 +247,7 @@ public final class CreekSystemTestExtensionTester {
         public TesterBuilder withDebugServices(final String... serviceNames) {
             return withDebugServices(
                     ServiceDebugInfo.serviceDebugInfo(
-                            DEFAULT_BASE_DEBUG_PORT, Set.of(serviceNames), Set.of()));
+                            DEFAULT_BASE_DEBUG_PORT, Set.of(serviceNames), Set.of(), Map.of()));
         }
 
         /**

--- a/test-util/src/test/java/org/creekservice/api/system/test/test/util/CreekSystemTestExtensionTesterTest.java
+++ b/test-util/src/test/java/org/creekservice/api/system/test/test/util/CreekSystemTestExtensionTesterTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.testing.EqualsTester;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Set;
@@ -190,6 +191,10 @@ class CreekSystemTestExtensionTesterTest {
                 contains(
                         mount(Paths.get("r/host/path"), Paths.get("r/container/path"), true),
                         mount(Paths.get("w/host/path"), Paths.get("w/container/path"), false)));
+
+        assertThat(tester.mountInfo().get(0).hostPath(), is(Path.of("r/host/path")));
+        assertThat(tester.mountInfo().get(0).containerPath(), is(Path.of("r/container/path")));
+        assertThat(tester.mountInfo().get(0).readOnly(), is(true));
     }
 
     @Test

--- a/test-util/src/test/java/org/creekservice/api/system/test/test/util/CreekSystemTestExtensionTesterTest.java
+++ b/test-util/src/test/java/org/creekservice/api/system/test/test/util/CreekSystemTestExtensionTesterTest.java
@@ -157,7 +157,8 @@ class CreekSystemTestExtensionTesterTest {
     @Test
     void shouldSupportConfiguringServiceDebugInfo() {
         // Given:
-        final ServiceDebugInfo debugServiceInfo = serviceDebugInfo(321, Set.of("a"), Set.of("b"));
+        final ServiceDebugInfo debugServiceInfo =
+                serviceDebugInfo(321, Set.of("a"), Set.of("b"), Map.of("k", "v"));
         tester = builder.withDebugServices(debugServiceInfo).build();
 
         // Then:
@@ -172,7 +173,7 @@ class CreekSystemTestExtensionTesterTest {
         // Then:
         assertThat(
                 tester.serviceDebugInfo(),
-                is(serviceDebugInfo(DEFAULT_BASE_DEBUG_PORT, Set.of("a"), Set.of())));
+                is(serviceDebugInfo(DEFAULT_BASE_DEBUG_PORT, Set.of("a"), Set.of(), Map.of())));
     }
 
     @Test


### PR DESCRIPTION
Extend the executor options to support environment variables to set on services being debugged. This is necessary to support service debugging in system tests.

### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/creek-service/.github/blob/main/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
