### PR TITLE
Initialize extensions per-suite & prepare resources

### DIFF
--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/Api.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/Api.java
@@ -29,6 +29,7 @@ import org.creekservice.internal.system.test.executor.api.test.env.suite.service
 import org.creekservice.internal.system.test.executor.execution.debug.ServiceDebugInfo;
 import org.creekservice.internal.system.test.executor.execution.listener.AddServicesUnderTestListener;
 import org.creekservice.internal.system.test.executor.execution.listener.InitializeResourcesListener;
+import org.creekservice.internal.system.test.executor.execution.listener.PrepareResourcesListener;
 import org.creekservice.internal.system.test.executor.execution.listener.StartServicesUnderTestListener;
 import org.creekservice.internal.system.test.executor.execution.listener.SuiteCleanUpListener;
 import org.creekservice.internal.system.test.executor.observation.LoggingTestEnvironmentListener;
@@ -77,6 +78,7 @@ public final class Api {
         api.tests().env().listeners().append(addServicesListener);
         creekTestExtensions.forEach(ext -> ext.initialize(api));
         api.tests().env().listeners().append(new InitializeResourcesListener(api));
+        api.tests().env().listeners().append(new PrepareResourcesListener(api));
         api.tests()
                 .env()
                 .listeners()

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/SystemTest.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/SystemTest.java
@@ -195,5 +195,10 @@ public final class SystemTest implements CreekSystemTest {
         public ComponentModelCollection model() {
             return api.components().model();
         }
+
+        /** Close all extensions. */
+        public void close() {
+            api.extensions().close();
+        }
     }
 }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/InitializeResourcesListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/InitializeResourcesListener.java
@@ -18,6 +18,7 @@ package org.creekservice.internal.system.test.executor.execution.listener;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -25,6 +26,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.creekservice.api.platform.metadata.OwnedResource;
+import org.creekservice.api.platform.metadata.ResourceDescriptor;
 import org.creekservice.api.platform.metadata.ServiceDescriptor;
 import org.creekservice.api.platform.resource.ResourceInitializer;
 import org.creekservice.api.system.test.extension.component.definition.ComponentDefinition;
@@ -57,7 +60,19 @@ public final class InitializeResourcesListener implements TestEnvironmentListene
     public InitializeResourcesListener(final SystemTest api) {
         this(
                 api,
-                ResourceInitializer.resourceInitializer(api.extensions().model()::resourceHandler));
+                ResourceInitializer.resourceInitializer(
+                        new ResourceInitializer.ResourceCreator() {
+                            @SuppressWarnings({"unchecked", "rawtypes"})
+                            @Override
+                            public <T extends ResourceDescriptor & OwnedResource> void ensure(
+                                    final Collection<T> creatableResources) {
+                                api.extensions()
+                                        .model()
+                                        .resourceHandler(
+                                                creatableResources.iterator().next().getClass())
+                                        .ensure((Collection) creatableResources);
+                            }
+                        }));
     }
 
     @VisibleForTesting

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/PrepareResourcesListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/PrepareResourcesListener.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.execution.listener;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.groupingBy;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.creekservice.api.platform.metadata.ResourceDescriptor;
+import org.creekservice.api.service.extension.component.model.ResourceHandler;
+import org.creekservice.api.system.test.extension.component.definition.ComponentDefinition;
+import org.creekservice.api.system.test.extension.test.env.listener.TestEnvironmentListener;
+import org.creekservice.api.system.test.extension.test.model.CreekTestSuite;
+import org.creekservice.internal.system.test.executor.api.SystemTest;
+
+/**
+ * Test listener that calls back into each client extension to allow it to any initialise internal
+ * state required to service requests on the resources it handles.
+ */
+public final class PrepareResourcesListener implements TestEnvironmentListener {
+
+    private final SystemTest api;
+
+    public PrepareResourcesListener(final SystemTest api) {
+        this.api = requireNonNull(api, "api");
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public void beforeSuite(final CreekTestSuite suite) {
+        final Map<URI, ResourceDescriptor> byId =
+                api.components().definitions().stream()
+                        .map(ComponentDefinition::descriptor)
+                        .flatMap(Optional::stream)
+                        .flatMap(ComponentDescriptor::resources)
+                        .collect(
+                                groupingBy(
+                                        ResourceDescriptor::id,
+                                        Collectors.collectingAndThen(
+                                                Collectors.toList(), l -> l.get(0))));
+
+        final Map<Class<? extends ResourceDescriptor>, List<ResourceDescriptor>> byType =
+                byId.values().stream().collect(groupingBy(ResourceDescriptor::getClass));
+
+        byType.forEach(
+                (type, resources) -> {
+                    final ResourceHandler handler = api.extensions().model().resourceHandler(type);
+                    handler.prepare(resources);
+                });
+    }
+}

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/SuiteCleanUpListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/SuiteCleanUpListener.java
@@ -26,7 +26,7 @@ import org.creekservice.internal.system.test.executor.api.SystemTest;
 
 /**
  * A test lifecycle listener that resets theServiceContainer and stops any services left running at
- * the end of a test suite.
+ * the end of a test suite, and closes any extensions.
  */
 public final class SuiteCleanUpListener implements TestEnvironmentListener {
 
@@ -47,5 +47,6 @@ public final class SuiteCleanUpListener implements TestEnvironmentListener {
     @Override
     public void afterSuite(final CreekTestSuite suite, final TestSuiteResult result) {
         api.tests().env().currentSuite().services().forEach(ServiceInstance::stop);
+        api.extensions().close();
     }
 }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/ApiTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/ApiTest.java
@@ -26,6 +26,7 @@ import org.creekservice.api.system.test.extension.CreekTestExtension;
 import org.creekservice.internal.system.test.executor.api.test.env.suite.service.ContainerFactory;
 import org.creekservice.internal.system.test.executor.execution.listener.AddServicesUnderTestListener;
 import org.creekservice.internal.system.test.executor.execution.listener.InitializeResourcesListener;
+import org.creekservice.internal.system.test.executor.execution.listener.PrepareResourcesListener;
 import org.creekservice.internal.system.test.executor.execution.listener.StartServicesUnderTestListener;
 import org.creekservice.internal.system.test.executor.execution.listener.SuiteCleanUpListener;
 import org.creekservice.internal.system.test.executor.observation.LoggingTestEnvironmentListener;
@@ -104,6 +105,18 @@ class ApiTest {
         inOrder.verify(ext0).initialize(api);
         inOrder.verify(api.tests().env().listeners())
                 .append(isA(InitializeResourcesListener.class));
+        inOrder.verify(api.tests().env().listeners()).append(isA(PrepareResourcesListener.class));
+    }
+
+    @Test
+    void shouldAddPrepareResourcesListener() {
+        // When:
+        initializeApi(api, containerFactory, List.of(ext0));
+
+        // Then:
+        final InOrder inOrder = inOrder(api.tests().env().listeners(), ext0);
+        inOrder.verify(ext0).initialize(api);
+        inOrder.verify(api.tests().env().listeners()).append(isA(PrepareResourcesListener.class));
         inOrder.verify(api.tests().env().listeners())
                 .append(isA(StartServicesUnderTestListener.class));
     }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/TestSuiteExecutorTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/TestSuiteExecutorTest.java
@@ -66,11 +66,11 @@ class TestSuiteExecutorTest {
     @Mock private TestEnvironmentListener listener;
     @Mock private CaseResult testResult;
     @Captor private ArgumentCaptor<Consumer<TestEnvironmentListener>> actionCaptor;
-    private TestSuiteExecutor suiteExecutor;
+    private TestSuiteExecutor.Executor suiteExecutor;
 
     @BeforeEach
     void setUp() {
-        suiteExecutor = new TestSuiteExecutor(listeners, inputters, testExecutor);
+        suiteExecutor = new TestSuiteExecutor.Executor(listeners, inputters, testExecutor);
 
         when(testCase0.name()).thenReturn("test0");
         when(testCase0.suite()).thenReturn(testSuite);
@@ -98,7 +98,7 @@ class TestSuiteExecutorTest {
         final SuiteResult result = suiteExecutor.executeSuite(testSuite);
 
         // Then:
-        assertAfterTestCalled(result);
+        assertAfterSuiteCalled(result);
     }
 
     @Test
@@ -142,7 +142,7 @@ class TestSuiteExecutorTest {
         final InOrder inOrder = inOrder(testExecutor);
         inOrder.verify(testExecutor).executeTest(testCase0);
         inOrder.verify(testExecutor).executeTest(testCase1);
-        assertAfterTestCalled(result);
+        assertAfterSuiteCalled(result);
     }
 
     @Test
@@ -164,7 +164,7 @@ class TestSuiteExecutorTest {
                 result.error().map(Exception::getMessage),
                 is(Optional.of("Suite setup failed for test suite: Fred, cause: boom")));
 
-        assertAfterTestCalled(result);
+        assertAfterSuiteCalled(result);
     }
 
     @Test
@@ -186,7 +186,7 @@ class TestSuiteExecutorTest {
                 is(Optional.of("Suite setup failed for test suite: Fred, cause: boom")));
         assertThat(result.error().map(Exception::getCause), is(Optional.of(cause)));
 
-        assertAfterTestCalled(result);
+        assertAfterSuiteCalled(result);
     }
 
     @Test
@@ -227,7 +227,7 @@ class TestSuiteExecutorTest {
         when(testSuite.tests()).thenReturn(List.of(tests));
     }
 
-    private void assertAfterTestCalled(final SuiteResult result) {
+    private void assertAfterSuiteCalled(final SuiteResult result) {
         verify(listeners).forEachReverse(actionCaptor.capture());
         actionCaptor.getValue().accept(listener);
         verify(listener).afterSuite(testSuite, result);

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/listener/PrepareResourcesListenerTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/listener/PrepareResourcesListenerTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2023 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.system.test.executor.execution.listener;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.creekservice.api.platform.metadata.ResourceDescriptor;
+import org.creekservice.api.service.extension.component.model.ResourceHandler;
+import org.creekservice.api.system.test.extension.component.definition.ComponentDefinition;
+import org.creekservice.internal.system.test.executor.api.SystemTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PrepareResourcesListenerTest {
+
+    private static final ResourceA RES_A_0 = new ResourceA(URI.create("id://A-0"));
+    private static final ResourceA RES_A_1 = new ResourceA(URI.create("id://A-1"));
+    private static final ResourceB RES_B_0 = new ResourceB(URI.create("id://B-0"));
+    private static final ResourceB RES_B_1 = new ResourceB(URI.create("id://B-1"));
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private SystemTest api;
+
+    @Mock private ComponentDefinition def0;
+    @Mock private ComponentDefinition def1;
+
+    @Mock private ComponentDescriptor desc0;
+    @Mock private ComponentDescriptor desc1;
+    @Mock private ResourceHandler<ResourceA> handlerA;
+    @Mock private ResourceHandler<ResourceB> handlerB;
+    private PrepareResourcesListener listener;
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @BeforeEach
+    void setUp() {
+        listener = new PrepareResourcesListener(api);
+
+        when(api.components().definitions().stream()).thenAnswer(inv -> Stream.of(def0, def1));
+
+        when(def0.descriptor()).thenReturn((Optional) Optional.of(desc0));
+        when(def1.descriptor()).thenReturn((Optional) Optional.of(desc1));
+
+        when(api.extensions().model().resourceHandler(ResourceA.class)).thenReturn(handlerA);
+        when(api.extensions().model().resourceHandler(ResourceB.class)).thenReturn(handlerB);
+
+        when(desc0.resources()).thenAnswer(inv -> Stream.of(RES_A_0, RES_B_0));
+    }
+
+    @Test
+    void shouldIgnoreDefinitionsWithNoDescriptor() {
+        // Given:
+        when(def0.descriptor()).thenReturn(Optional.empty());
+        when(def1.descriptor()).thenReturn(Optional.empty());
+
+        // When:
+        listener.beforeSuite(null);
+
+        // Then:
+        verify(api.extensions().model(), never()).resourceHandler(any());
+    }
+
+    @Test
+    void shouldPrepareAllOfTheSameTypeInOneCall() {
+        // Given:
+        when(desc0.resources()).thenAnswer(inv -> Stream.of(RES_A_0, RES_A_1));
+        when(desc1.resources()).thenAnswer(inv -> Stream.of(RES_B_0, RES_B_1));
+
+        // When:
+        listener.beforeSuite(null);
+
+        // Then:
+        verify(handlerA).prepare(List.of(RES_A_0, RES_A_1));
+        verify(handlerB).prepare(List.of(RES_B_0, RES_B_1));
+    }
+
+    @Test
+    void shouldPrepareOnlyFirstById() {
+        // Given:
+        when(desc0.resources())
+                .thenAnswer(inv -> Stream.of(RES_A_0, RES_A_1, new ResourceA(RES_A_1.id())));
+        when(desc1.resources()).thenAnswer(inv -> Stream.of(RES_A_0, new ResourceA(RES_A_0.id())));
+
+        // When:
+        listener.beforeSuite(null);
+
+        // Then:
+        verify(handlerA).prepare(List.of(RES_A_0, RES_A_1));
+    }
+
+    @Test
+    void shouldThrowIfNoResourceHandlerRegistered() {
+        // Given:
+        final Exception expected = new RuntimeException("Boom");
+        when(api.extensions().model().resourceHandler(any())).thenThrow(expected);
+
+        // When:
+        final Exception e = assertThrows(RuntimeException.class, () -> listener.beforeSuite(null));
+
+        // Then:
+        assertThat(e, is(expected));
+    }
+
+    @Test
+    void shouldThrowIfPrepareFails() {
+        // Given:
+        final Exception expected = new RuntimeException("Boom");
+        doThrow(expected).when(handlerA).prepare(any());
+
+        // When:
+        final Exception e = assertThrows(RuntimeException.class, () -> listener.beforeSuite(null));
+
+        // Then:
+        assertThat(e, is(expected));
+    }
+
+    private static final class ResourceA implements ResourceDescriptor {
+        private final URI id;
+
+        private ResourceA(final URI id) {
+            this.id = id;
+        }
+
+        @Override
+        public URI id() {
+            return id;
+        }
+    }
+
+    private static final class ResourceB implements ResourceDescriptor {
+        private final URI id;
+
+        private ResourceB(final URI id) {
+            this.id = id;
+        }
+
+        @Override
+        public URI id() {
+            return id;
+        }
+    }
+}

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/listener/SuiteCleanUpListenerTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/execution/listener/SuiteCleanUpListenerTest.java
@@ -65,4 +65,13 @@ class SuiteCleanUpListenerTest {
         actionCaptor.getValue().accept(service);
         verify(service).stop();
     }
+
+    @Test
+    void shouldCloseExtensionsAfterSuite() {
+        // When:
+        listener.afterSuite(null, null);
+
+        // Then:
+        verify(api.extensions()).close();
+    }
 }


### PR DESCRIPTION
Prep work for: https://github.com/creek-service/creek-kafka/issues/25

Initialize test extensions per-test-suite. Each test suite is self-contained, with their own Docker containers and state.  It makes things much more simple if test extensions are created and initialised for a specific test suite.

Ensure extensions are automatically closed at the end of the test suite run, allowing them to release any resources.

Make use of the new `prepare` method on the `ResourceHandler` to instruct Creek extensions to prepare internal state to interact with the supplied resources.

