### PR TITLE
upgrade Java 11 to 17

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
     gradlePluginPortal()
 }
 
-val jvmTargetVer = JavaLanguageVersion.of(11)
+val jvmTargetVer = JavaLanguageVersion.of(17)
 
 java {
     toolchain.languageVersion.set(jvmTargetVer)

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -94,7 +94,7 @@ tasks.test {
 
 spotless {
     java {
-        googleJavaFormat("1.15.0").aosp().reflowLongStrings()
+        googleJavaFormat("1.25.2").aosp().reflowLongStrings()
         leadingTabsToSpaces()
         importOrder()
         removeUnusedImports()

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -43,7 +43,7 @@ group = "org.creekservice"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/PrepareResourcesListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/PrepareResourcesListener.java
@@ -40,6 +40,9 @@ public final class PrepareResourcesListener implements TestEnvironmentListener {
 
     private final SystemTest api;
 
+    /**
+     * @param api the system test API
+     */
     public PrepareResourcesListener(final SystemTest api) {
         this.api = requireNonNull(api, "api");
     }


### PR DESCRIPTION
Upgrades Java version from 11 to 17.

## Files changed
- `buildSrc/build.gradle.kts`: `JavaLanguageVersion.of(11)` → `JavaLanguageVersion.of(17)`
- `buildSrc/src/main/kotlin/creek-common-convention.gradle.kts`: `JavaLanguageVersion.of(11)` → `JavaLanguageVersion.of(17)`

Note: GitHub Actions workflow files were already referencing Java 17.