### PR TITLE
Replace deprecated test container mount usage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ subprojects {
 
     extra.apply {
         set("creekVersion", project.version)
-        set("testContainersVersion", "1.19.1")  // https://mvnrepository.com/artifact/org.testcontainers/testcontainers
+        set("testContainersVersion", "1.21.4")  // https://mvnrepository.com/artifact/org.testcontainers/testcontainers
         set("spotBugsVersion", "4.9.8")         // https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-annotations
         set("jacksonVersion", "2.21.2")         // https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind
         set("jacksonAnnotationsVersion", "2.20")// https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations

--- a/executor/src/main/java/module-info.java
+++ b/executor/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module creek.system.test.executor {
     requires java.management;
     requires com.github.spotbugs.annotations;
     requires testcontainers;
+    requires org.apache.commons.compress;
     requires com.github.dockerjava.api;
     requires com.fasterxml.jackson.databind;
     requires com.fasterxml.jackson.dataformat.xml;

--- a/executor/src/main/java/org/creekservice/api/system/test/executor/ExecutorOptions.java
+++ b/executor/src/main/java/org/creekservice/api/system/test/executor/ExecutorOptions.java
@@ -221,5 +221,16 @@ public interface ExecutorOptions {
             requireNonNull(containerPath, "containerPath");
             requireNonNull(direction, "direction");
         }
+
+        @Override
+        public String toString() {
+            return "DirectoryInfo[hostPath="
+                    + hostPath.toString().replace('\\', '/')
+                    + ", containerPath="
+                    + containerPath.toString().replace('\\', '/')
+                    + ", direction="
+                    + direction
+                    + "]";
+        }
     }
 }

--- a/executor/src/main/java/org/creekservice/api/system/test/executor/ExecutorOptions.java
+++ b/executor/src/main/java/org/creekservice/api/system/test/executor/ExecutorOptions.java
@@ -16,6 +16,8 @@
 
 package org.creekservice.api.system.test.executor;
 
+import static java.util.Objects.requireNonNull;
+
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collection;
@@ -66,12 +68,13 @@ public interface ExecutorOptions {
     }
 
     /**
-     * Info about the which services should be debugged.
+     * Info about which services should be debugged.
      *
      * <p>In addition to providing this information, actually debugging a service requires the
      * caller to provide the actual debugging mechanism. This will generally involve providing a
-     * {@link #mountInfo() mount} containing a Java agent, and enabling the agent by setting {@code
-     * JAVA_TOOLS_OPTIONS} environment variable via {@link ServiceDebugInfo#env()}.
+     * {@link #transferables() directory} containing a Java agent to copy to the container, and
+     * enabling the agent by setting {@code JAVA_TOOLS_OPTIONS} environment variable via {@link
+     * ServiceDebugInfo#env()}.
      *
      * @return info about which services should be debugged.
      */
@@ -80,10 +83,10 @@ public interface ExecutorOptions {
     }
 
     /**
-     * @return info about any mounts to mount into the Docker containers running the
+     * @return info about what to copy to or from the Docker containers running the
      *     services-under-test or service-being-debugged.
      */
-    default Collection<MountInfo> mountInfo() {
+    default Collection<DirectoryInfo> transferables() {
         return List.of();
     }
 
@@ -166,21 +169,57 @@ public interface ExecutorOptions {
         }
     }
 
-    /** Information about a single mount. */
-    interface MountInfo {
-        /**
-         * @return the path on the host machine to mount.
-         */
-        Path hostPath();
+    /** Controls the direction of file transfer. */
+    enum CopyDirection {
+        /** Copy host → container only (before start). */
+        COPY_TO_CONTAINER(true, false),
+        /** Copy container → host only (after stop). */
+        COPY_FROM_CONTAINER(false, true),
+        /** Copy host → container before start, and container → host after stop. */
+        COPY_TO_AND_FROM_CONTAINER(true, true);
+
+        private final boolean copyTo;
+        private final boolean copyFrom;
+
+        CopyDirection(final boolean copyTo, final boolean copyFrom) {
+            this.copyTo = copyTo;
+            this.copyFrom = copyFrom;
+        }
 
         /**
-         * @return the path within the Docker container to mount.
+         * @return {@code true} if files should be copied from the host to the container.
          */
-        Path containerPath();
+        public boolean copyTo() {
+            return copyTo;
+        }
 
         /**
-         * @return {@code true} if the mount is read-only.
+         * @return {@code true} if files should be copied from the container to the host.
          */
-        boolean readOnly();
+        public boolean copyFrom() {
+            return copyFrom;
+        }
+    }
+
+    /**
+     * Information about a directory to copy to/from a container.
+     *
+     * @param hostPath the path on the host machine.
+     * @param containerPath the path within the Docker container.
+     * @param direction the direction of file transfer.
+     */
+    record DirectoryInfo(Path hostPath, Path containerPath, CopyDirection direction) {
+        /**
+         * Validates required parameters.
+         *
+         * @param hostPath the path on the host machine.
+         * @param containerPath the path within the Docker container.
+         * @param direction the direction of file transfer.
+         */
+        public DirectoryInfo {
+            requireNonNull(hostPath, "hostPath");
+            requireNonNull(containerPath, "containerPath");
+            requireNonNull(direction, "direction");
+        }
     }
 }

--- a/executor/src/main/java/org/creekservice/api/system/test/executor/SystemTestExecutor.java
+++ b/executor/src/main/java/org/creekservice/api/system/test/executor/SystemTestExecutor.java
@@ -136,7 +136,7 @@ public final class SystemTestExecutor {
                                 options.serviceDebugInfo()
                                         .map(ServiceDebugInfo::copyOf)
                                         .orElse(ServiceDebugInfo.none()),
-                                options.mountInfo(),
+                                options.transferables(),
                                 options.env());
 
         final TestPackagesLoader loader =

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/Api.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/Api.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.api.platform.metadata.ComponentDescriptors;
-import org.creekservice.api.system.test.executor.ExecutorOptions.MountInfo;
+import org.creekservice.api.system.test.executor.ExecutorOptions.DirectoryInfo;
 import org.creekservice.api.system.test.extension.CreekTestExtension;
 import org.creekservice.api.system.test.extension.CreekTestExtensions;
 import org.creekservice.internal.system.test.executor.api.test.env.suite.service.ContainerFactory;
@@ -47,17 +47,17 @@ public final class Api {
      * Initialise the test api
      *
      * @param serviceDebugInfo info about which services should be debugged.
-     * @param mountInfo info about container mounts.
+     * @param transferables info about things to transfer to/from containers.
      * @param env environment vars to set on services under test.
      * @return the initialised test api.
      */
     public static SystemTest initializeApi(
             final ServiceDebugInfo serviceDebugInfo,
-            final Collection<MountInfo> mountInfo,
+            final Collection<DirectoryInfo> transferables,
             final Map<String, String> env) {
 
         final ContainerFactory containerFactory =
-                new ContainerFactory(serviceDebugInfo, mountInfo, env);
+                new ContainerFactory(serviceDebugInfo, transferables, env);
 
         return initializeApi(
                 new SystemTest(loadComponents(), containerFactory),

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerFactory.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerFactory.java
@@ -18,6 +18,8 @@ package org.creekservice.internal.system.test.executor.api.test.env.suite.servic
 
 import static java.util.Objects.requireNonNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -27,18 +29,18 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.creekservice.api.base.annotation.VisibleForTesting;
-import org.creekservice.api.system.test.executor.ExecutorOptions.MountInfo;
+import org.creekservice.api.system.test.executor.ExecutorOptions.DirectoryInfo;
 import org.creekservice.api.system.test.extension.test.env.listener.TestEnvironmentListener;
 import org.creekservice.api.system.test.extension.test.model.CreekTestSuite;
 import org.creekservice.api.system.test.extension.test.model.TestSuiteResult;
 import org.creekservice.internal.system.test.executor.execution.debug.ServiceDebugInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 /** Factory that creates the Docker containers used to run services */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -47,7 +49,7 @@ public final class ContainerFactory implements TestEnvironmentListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(ContainerFactory.class);
 
     private final ServiceDebugInfo serviceDebugInfo;
-    private final List<MountInfo> mountInfo;
+    private final List<DirectoryInfo> transferables;
     private final Map<String, String> env;
     private final RegularContainerFactory regularFactory;
     private final DebugContainerFactory debugFactory;
@@ -56,19 +58,19 @@ public final class ContainerFactory implements TestEnvironmentListener {
     private final AtomicReference<Network> network = new AtomicReference<>();
 
     /**
-     * Create factory instance.
+     * Create a factory instance.
      *
      * @param serviceDebugInfo info on what services to debug.
-     * @param mountInfo info on what mounts to add to containers.
+     * @param transferables info on what to copy to/from containers.
      * @param env environment vars to set on services-under-test.
      */
     public ContainerFactory(
             final ServiceDebugInfo serviceDebugInfo,
-            final Collection<MountInfo> mountInfo,
+            final Collection<DirectoryInfo> transferables,
             final Map<String, String> env) {
         this(
                 serviceDebugInfo,
-                mountInfo,
+                transferables,
                 env,
                 new RegularContainerFactory(),
                 new DebugContainerFactory(),
@@ -78,13 +80,13 @@ public final class ContainerFactory implements TestEnvironmentListener {
     @VisibleForTesting
     ContainerFactory(
             final ServiceDebugInfo serviceDebugInfo,
-            final Collection<MountInfo> mountInfo,
+            final Collection<DirectoryInfo> transferables,
             final Map<String, String> env,
             final RegularContainerFactory regularFactory,
             final DebugContainerFactory debugFactory,
             final Supplier<Network> networkSupplier) {
         this.serviceDebugInfo = requireNonNull(serviceDebugInfo, "serviceDebugInfo");
-        this.mountInfo = List.copyOf(requireNonNull(mountInfo, "mountInfo"));
+        this.transferables = List.copyOf(requireNonNull(transferables, "transferables"));
         this.env = Map.copyOf(requireNonNull(env, "env"));
         this.regularFactory = requireNonNull(regularFactory, "regularFactory");
         this.debugFactory = requireNonNull(debugFactory, "debugFactory");
@@ -99,9 +101,10 @@ public final class ContainerFactory implements TestEnvironmentListener {
      * @param instanceName the name of instance being created
      * @param serviceName the name of the service the instance will run
      * @param serviceUnderTest {@code true} if the service is under test.
-     * @return the created container.
+     * @return the created container along with any transferables to copy from the container after
+     *     it stops.
      */
-    public GenericContainer<?> create(
+    public CreatedContainer create(
             final DockerImageName imageName,
             final String instanceName,
             final String serviceName,
@@ -116,8 +119,9 @@ public final class ContainerFactory implements TestEnvironmentListener {
 
         setEnv(instanceName, container, serviceUnderTest, serviceDebugPort);
 
-        if (serviceUnderTest || serviceDebugPort.isPresent()) {
-            setMounts(instanceName, container);
+        final boolean transfer = serviceUnderTest || serviceDebugPort.isPresent();
+        if (transfer) {
+            copyTransferablesToContainer(instanceName, container);
         }
 
         container
@@ -127,7 +131,44 @@ public final class ContainerFactory implements TestEnvironmentListener {
                         new Slf4jLogConsumer(LoggerFactory.getLogger(instanceName))
                                 .withPrefix(instanceName));
 
-        return container;
+        final List<DirectoryInfo> writableCopies =
+                transfer
+                        ? transferables.stream().filter(t -> t.direction().copyFrom()).toList()
+                        : List.of();
+
+        return new CreatedContainer(container, writableCopies);
+    }
+
+    /**
+     * Holds the result of {@link #create}, bundling the container with any transferables to copy
+     * when the container closes.
+     *
+     * @param container the created container.
+     * @param transferables transferables to transfer when the container closes.
+     */
+    public record CreatedContainer(
+            GenericContainer<?> container, List<DirectoryInfo> transferables) {
+
+        /**
+         * Create an instance
+         *
+         * @param container the created container.
+         * @param transferables any transferables to copy from the container when it stops.
+         */
+        @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "intentional exposure")
+        public CreatedContainer {
+            requireNonNull(container, "container");
+            transferables = List.copyOf(requireNonNull(transferables, "writableCopies"));
+        }
+
+        /**
+         * @return the created container.
+         */
+        @Override
+        @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intentional exposure")
+        public GenericContainer<?> container() {
+            return container;
+        }
     }
 
     @SuppressWarnings("resource")
@@ -185,23 +226,28 @@ public final class ContainerFactory implements TestEnvironmentListener {
         }
     }
 
-    private void setMounts(final String instanceName, final GenericContainer<?> container) {
-        mountInfo.forEach(
-                mount -> {
-                    LOGGER.info(
-                            "Adding container mount. instance: "
-                                    + instanceName
-                                    + ". hostPath "
-                                    + mount.hostPath()
-                                    + ", containerPath: "
-                                    + mount.containerPath()
-                                    + ", read-only: "
-                                    + mount.readOnly());
+    private void copyTransferablesToContainer(
+            final String instanceName, final GenericContainer<?> container) {
+        transferables.stream()
+                .filter(t -> t.direction().copyTo())
+                .forEach(
+                        transferable -> {
+                            LOGGER.info(
+                                    "Copying to container. instance: {}, hostPath: {},"
+                                            + " containerPath: {}",
+                                    instanceName,
+                                    transferable.hostPath(),
+                                    transferable.containerPath());
 
-                    container.withFileSystemBind(
-                            mount.hostPath().toString(),
-                            mount.containerPath().toString(),
-                            mount.readOnly() ? BindMode.READ_ONLY : BindMode.READ_WRITE);
-                });
+                            if (!Files.exists(transferable.hostPath())) {
+                                throw new IllegalArgumentException(
+                                        "Host path does not exist for transferable: "
+                                                + transferable);
+                            }
+
+                            container.withCopyFileToContainer(
+                                    MountableFile.forHostPath(transferable.hostPath()),
+                                    transferable.containerPath().toString() + "/");
+                        });
     }
 }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstance.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstance.java
@@ -23,19 +23,27 @@ import static org.creekservice.api.base.type.RuntimeIOException.runtimeIOExcepti
 import static org.creekservice.api.system.test.extension.test.env.suite.service.ServiceInstance.ExecResult.execResult;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.ConcurrentModificationException;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.base.type.Preconditions;
 import org.creekservice.api.platform.metadata.ServiceDescriptor;
+import org.creekservice.api.system.test.executor.ExecutorOptions.DirectoryInfo;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ConfigurableServiceInstance;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ServiceInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.ToStringConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
@@ -51,6 +59,8 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
     private final GenericContainer<?> container;
     private final Optional<? extends ServiceDescriptor> descriptor;
     private final Consumer<ServiceInstance> startedCallback;
+    private final List<DirectoryInfo> transferables;
+    private final ToStringConsumer logConsumer = new ToStringConsumer();
     private Duration startUpTimeOut = Duration.ofSeconds(30);
     private Duration shutDownTimeOut = Duration.ofSeconds(30);
 
@@ -60,19 +70,23 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
      * @param container the docker container.
      * @param descriptor the service's descriptor, if the service has one.
      * @param startedCallback a callback to be called when the instance has started.
+     * @param transferables list of transferables to transfer from the container back to the host
+     *     after the container stops.
      */
     public ContainerInstance(
             final String name,
             final DockerImageName imageName,
             final GenericContainer<?> container,
             final Optional<? extends ServiceDescriptor> descriptor,
-            final Consumer<ServiceInstance> startedCallback) {
+            final Consumer<ServiceInstance> startedCallback,
+            final List<DirectoryInfo> transferables) {
         this(
                 name,
                 imageName,
                 container,
                 descriptor,
                 startedCallback,
+                transferables,
                 Thread.currentThread().getId());
     }
 
@@ -83,6 +97,7 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
             final GenericContainer<?> container,
             final Optional<? extends ServiceDescriptor> descriptor,
             final Consumer<ServiceInstance> startedCallback,
+            final List<DirectoryInfo> transferables,
             final long threadId) {
         this.threadId = threadId;
         this.name = requireNonBlank(name, "name");
@@ -90,6 +105,8 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
         this.container = requireNonNull(container, "container");
         this.descriptor = requireNonNull(descriptor, "descriptor");
         this.startedCallback = requireNonNull(startedCallback, "startedCallback");
+        this.transferables = List.copyOf(requireNonNull(transferables, "transferables"));
+        this.container.withLogConsumer(logConsumer);
     }
 
     @Override
@@ -123,7 +140,7 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
                     imageName,
                     container.getContainerId());
         } catch (final Exception e) {
-            final String logs = container.getLogs();
+            final String logs = logConsumer.toUtf8String();
             stop();
             throw new FailedToStartServiceException(name, imageName, logs, e);
         }
@@ -173,7 +190,8 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
 
         // First, attempt a graceful shutdown:
         gracefulStop();
-        // Then, if still running, kill, and always remove container:
+        copyTransferablesToHost();
+        // Then, if still running, kill, and always remove the container:
         killAndRemove();
     }
 
@@ -287,6 +305,54 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
         }
     }
 
+    private void copyTransferablesToHost() {
+        transferables.forEach(
+                transferable -> {
+                    LOGGER.info(
+                            "Copying from container to host. instance: {}, containerPath: {},"
+                                    + " hostPath: {}",
+                            name,
+                            transferable.containerPath(),
+                            transferable.hostPath());
+                    try {
+                        container.copyFileFromContainer(
+                                transferable.containerPath().toString(),
+                                inputStream ->
+                                        extractTarToDirectory(
+                                                (TarArchiveInputStream) inputStream,
+                                                transferable.hostPath()));
+                    } catch (final Exception e) {
+                        throw new FailedToCopyFileFromServiceException(
+                                name,
+                                imageName,
+                                transferable.containerPath(),
+                                transferable.hostPath(),
+                                e);
+                    }
+                });
+    }
+
+    private static Void extractTarToDirectory(final TarArchiveInputStream tar, final Path hostPath)
+            throws IOException {
+        for (TarArchiveEntry entry = tar.getCurrentEntry();
+                entry != null;
+                entry = tar.getNextTarEntry()) {
+            if (entry.isDirectory()) {
+                continue;
+            }
+
+            final String name = entry.getName();
+            final int pos = name.indexOf('/');
+            final Path target = hostPath.resolve(name.substring(pos + 1));
+            final Path parent = target.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            Files.copy(tar, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+        return null;
+    }
+
     private void gracefulStop() {
         if (!container.isRunning()) {
             LOGGER.warn(
@@ -357,6 +423,28 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
                             + lineSeparator()
                             + "Logs: "
                             + logs,
+                    cause);
+        }
+    }
+
+    private static final class FailedToCopyFileFromServiceException extends RuntimeException {
+        FailedToCopyFileFromServiceException(
+                final String name,
+                final DockerImageName imageName,
+                final Path containerPath,
+                final Path hostPath,
+                final Throwable cause) {
+            super(
+                    "Failed to copy file from service: "
+                            + name
+                            + ", image: "
+                            + imageName
+                            + lineSeparator()
+                            + "Container path: "
+                            + containerPath
+                            + lineSeparator()
+                            + "Host path: "
+                            + hostPath,
                     cause);
         }
     }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstance.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstance.java
@@ -334,6 +334,8 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
 
     private static Void extractTarToDirectory(final TarArchiveInputStream tar, final Path hostPath)
             throws IOException {
+        final Path normalizedHostPath = hostPath.toAbsolutePath().normalize();
+
         for (TarArchiveEntry entry = tar.getCurrentEntry();
                 entry != null;
                 entry = tar.getNextTarEntry()) {
@@ -343,7 +345,12 @@ public final class ContainerInstance implements ConfigurableServiceInstance {
 
             final String name = entry.getName();
             final int pos = name.indexOf('/');
-            final Path target = hostPath.resolve(name.substring(pos + 1));
+            final String entryRelativeName = name.substring(pos + 1);
+            final Path target = normalizedHostPath.resolve(entryRelativeName).normalize();
+            if (!target.startsWith(normalizedHostPath)) {
+                throw new IOException("Bad tar entry outside target dir: " + name);
+            }
+
             final Path parent = target.getParent();
             if (parent != null) {
                 Files.createDirectories(parent);

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/DockerServiceContainer.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/DockerServiceContainer.java
@@ -28,7 +28,7 @@ import org.creekservice.api.system.test.extension.component.definition.ServiceDe
 import org.creekservice.api.system.test.extension.test.env.suite.service.ConfigurableServiceInstance;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ServiceInstance;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ServiceInstanceContainer;
-import org.testcontainers.containers.GenericContainer;
+import org.creekservice.internal.system.test.executor.api.test.env.suite.service.ContainerFactory.CreatedContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /** A local, docker based, implementation of {@link ServiceInstanceContainer}. */
@@ -63,7 +63,7 @@ public final class DockerServiceContainer implements ServiceInstanceContainer {
         final String instanceName = naming.instanceName(def.name());
         final DockerImageName imageName = DockerImageName.parse(def.dockerImage());
 
-        final GenericContainer<?> container =
+        final CreatedContainer created =
                 containerFactory.create(
                         imageName, instanceName, def.name(), def.descriptor().isPresent());
 
@@ -71,9 +71,10 @@ public final class DockerServiceContainer implements ServiceInstanceContainer {
                 new ContainerInstance(
                                 instanceName,
                                 imageName,
-                                container,
+                                created.container(),
                                 def.descriptor(),
-                                def::instanceStarted)
+                                def::instanceStarted,
+                                created.transferables())
                         .setStartupAttempts(CONTAINER_START_UP_ATTEMPTS)
                         .setStartupTimeout(CONTAINER_START_UP_TIMEOUT);
 

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/cli/PicoCliParser.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/cli/PicoCliParser.java
@@ -17,7 +17,6 @@
 package org.creekservice.internal.system.test.executor.cli;
 
 import static java.lang.System.lineSeparator;
-import static org.creekservice.api.base.type.Preconditions.requireNonEmpty;
 import static org.creekservice.internal.system.test.executor.execution.debug.ServiceDebugInfo.DEFAULT_BASE_DEBUG_PORT;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -209,46 +208,58 @@ public final class PicoCliParser {
                                 + " service-under-test.")
         private Map<String, String> env = Map.of();
 
-        private List<MountInfo> readOnlyMounts = new ArrayList<>(2);
+        private List<DirectoryInfo> readOnlyMounts = new ArrayList<>(2);
 
         /**
-         * Method for adding read-only mount points.
+         * Method for adding read-only directories to copy to services under test or being debugged.
          *
-         * @param mounts the map of host to container paths to mount.
+         * @param readOnly the map of host to container paths to copy.
          */
         @Option(
-                names = {"-mr", "--mount-read-only"},
+                names = {"--mount-read-only", "--dir-copy-read-only"},
                 split = ",",
                 description =
-                        "Comma seperated list of hostPath=containerPath read-only mount points to"
-                                + " set on each service-under-test.")
-        public void setReadOnlyMount(final Map<String, String> mounts) {
-            validateMounts(mounts);
+                        "Comma seperated list of hostPath=containerPath read-only directories to"
+                                + " copy to each service-under-test.")
+        public void setReadOnlyMount(final Map<String, String> readOnly) {
+            validateTransferables(readOnly);
             readOnlyMounts =
-                    mounts.entrySet().stream()
-                            .map(e -> new Mount(e.getKey(), e.getValue(), true))
-                            .collect(Collectors.toUnmodifiableList());
+                    readOnly.entrySet().stream()
+                            .map(
+                                    e ->
+                                            new DirectoryInfo(
+                                                    toPath(e.getKey()),
+                                                    toPath(e.getValue()),
+                                                    CopyDirection.COPY_TO_CONTAINER))
+                            .toList();
         }
 
-        private List<MountInfo> writeableMounts = new ArrayList<>(1);
+        private List<DirectoryInfo> writeableMounts = new ArrayList<>(2);
 
         /**
-         * Method for adding writable mount points.
+         * Method for adding writable directories to copy to services under test or being debugged,
+         * and to copy back when the service stops.
          *
-         * @param mounts the map of host to container paths to mount.
+         * @param writable the map of host to container paths to copy.
          */
         @Option(
-                names = {"-mw", "--mount-writable"},
+                names = {"--mount-writable", "--dir-copy-read-write"},
                 split = ",",
                 description =
-                        "Comma seperated list of hostPath=containerPath writable mount points to"
+                        "Comma seperated list of hostPath=containerPath writable file copies to"
                                 + " set on each service-under-test.")
-        public void setWritableMount(final Map<String, String> mounts) {
-            validateMounts(mounts);
+        public void setWritableMount(final Map<String, String> writable) {
+            validateTransferables(writable);
+
             writeableMounts =
-                    mounts.entrySet().stream()
-                            .map(e -> new Mount(e.getKey(), e.getValue(), false))
-                            .collect(Collectors.toUnmodifiableList());
+                    writable.entrySet().stream()
+                            .map(
+                                    e ->
+                                            new DirectoryInfo(
+                                                    toPath(e.getKey()),
+                                                    toPath(e.getValue()),
+                                                    CopyDirection.COPY_TO_AND_FROM_CONTAINER))
+                            .toList();
         }
 
         @Override
@@ -294,7 +305,7 @@ public final class PicoCliParser {
         }
 
         @Override
-        public Collection<MountInfo> mountInfo() {
+        public Collection<DirectoryInfo> transferables() {
             return Lists.combineList(readOnlyMounts, writeableMounts);
         }
 
@@ -333,10 +344,10 @@ public final class PicoCliParser {
                     + formatMap(env)
                     + lineSeparator()
                     + "--mount-read-only="
-                    + formatMounts(readOnlyMounts)
+                    + formatTransferables(readOnlyMounts)
                     + lineSeparator()
                     + "--mount-writable="
-                    + formatMounts(writeableMounts);
+                    + formatTransferables(writeableMounts);
         }
 
         private String formatList(final Set<String> list) {
@@ -354,16 +365,16 @@ public final class PicoCliParser {
                             .collect(Collectors.joining(","));
         }
 
-        private static String formatMounts(final List<MountInfo> mounts) {
-            return mounts.isEmpty()
+        private static String formatTransferables(final List<DirectoryInfo> transferables) {
+            return transferables.isEmpty()
                     ? NOT_SET
-                    : mounts.stream()
-                            .map(m -> m.hostPath() + "=" + m.containerPath())
+                    : transferables.stream()
+                            .map(info -> info.hostPath() + "=" + info.containerPath())
                             .collect(Collectors.joining(","));
         }
 
-        private static void validateMounts(final Map<String, String> mounts) {
-            mounts.forEach(
+        private static void validateTransferables(final Map<String, String> transferables) {
+            transferables.forEach(
                     (hostPath, containerPath) -> {
                         if (hostPath.trim().isEmpty()) {
                             throw new IllegalArgumentException("Host path can not be empty");
@@ -374,32 +385,11 @@ public final class PicoCliParser {
                     });
         }
 
-        private static final class Mount implements MountInfo {
-            private final Path hostPath;
-            private final Path containerPath;
-            private final boolean readOnly;
-
-            @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Trusted user input")
-            Mount(final String hostPath, final String containerPath, final boolean readOnly) {
-                this.hostPath = Paths.get(requireNonEmpty(hostPath, "hostPath"));
-                this.containerPath = Paths.get(requireNonEmpty(containerPath, "containerPath"));
-                this.readOnly = readOnly;
-            }
-
-            @Override
-            public Path hostPath() {
-                return hostPath;
-            }
-
-            @Override
-            public Path containerPath() {
-                return containerPath;
-            }
-
-            @Override
-            public boolean readOnly() {
-                return readOnly;
-            }
+        @SuppressFBWarnings(
+                value = "PATH_TRAVERSAL_IN",
+                justification = "API needs to allow any file to be mounted")
+        private static Path toPath(final String path) {
+            return Paths.get(path);
         }
     }
 

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/expectation/Verifiers.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/expectation/Verifiers.java
@@ -23,7 +23,6 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.creekservice.api.system.test.extension.test.model.Expectation;
 import org.creekservice.api.system.test.extension.test.model.ExpectationHandler;
 import org.creekservice.api.system.test.extension.test.model.ExpectationHandler.Verifier;
@@ -67,7 +66,7 @@ public final class Verifiers {
         final List<Verifier> verifiers =
                 byHandler.entrySet().stream()
                         .map(e -> prepare(e.getKey(), e.getValue(), test))
-                        .collect(Collectors.toUnmodifiableList());
+                        .toList();
 
         return () -> verifiers.forEach(Verifier::verify);
     }

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/PrepareResourcesListener.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/execution/listener/PrepareResourcesListener.java
@@ -41,7 +41,7 @@ public final class PrepareResourcesListener implements TestEnvironmentListener {
     private final SystemTest api;
 
     /**
-     * @param api the system test API
+     * @param api the system test API.
      */
     public PrepareResourcesListener(final SystemTest api) {
         this.api = requireNonNull(api, "api");

--- a/executor/src/test/java/org/creekservice/api/system/test/executor/ExecutorOptionsTest.java
+++ b/executor/src/test/java/org/creekservice/api/system/test/executor/ExecutorOptionsTest.java
@@ -116,7 +116,8 @@ class ExecutorOptionsTest {
         assertThat(
                 copy.toString(),
                 is(
-                        "DirectoryInfo[hostPath=r/host/path, containerPath=r/container/path,"
-                                + " direction=COPY_TO_CONTAINER]"));
+                        "DirectoryInfo[hostPath=%s, containerPath=%s, direction=COPY_TO_CONTAINER]"
+                                .formatted(
+                                        Paths.get("r/host/path"), Paths.get("r/container/path"))));
     }
 }

--- a/executor/src/test/java/org/creekservice/api/system/test/executor/ExecutorOptionsTest.java
+++ b/executor/src/test/java/org/creekservice/api/system/test/executor/ExecutorOptionsTest.java
@@ -116,8 +116,7 @@ class ExecutorOptionsTest {
         assertThat(
                 copy.toString(),
                 is(
-                        "DirectoryInfo[hostPath=%s, containerPath=%s, direction=COPY_TO_CONTAINER]"
-                                .formatted(
-                                        Paths.get("r/host/path"), Paths.get("r/container/path"))));
+                        "DirectoryInfo[hostPath=r/host/path, containerPath=r/container/path,"
+                                + " direction=COPY_TO_CONTAINER]"));
     }
 }

--- a/executor/src/test/java/org/creekservice/api/system/test/executor/ExecutorOptionsTest.java
+++ b/executor/src/test/java/org/creekservice/api/system/test/executor/ExecutorOptionsTest.java
@@ -89,8 +89,8 @@ class ExecutorOptionsTest {
     }
 
     @Test
-    void shouldDefaultToNoMounts() {
-        assertThat(options.mountInfo(), is(empty()));
+    void shouldDefaultToNoTransferables() {
+        assertThat(options.transferables(), is(empty()));
     }
 
     @Test
@@ -101,5 +101,22 @@ class ExecutorOptionsTest {
     @Test
     void shouldDefaultToNoDebugEnv() {
         assertThat(debugInfo.env(), is(Map.of()));
+    }
+
+    @Test
+    void shouldToStringOnDirectoryInfo() {
+        // Given:
+        final ExecutorOptions.DirectoryInfo copy =
+                new ExecutorOptions.DirectoryInfo(
+                        Paths.get("r/host/path"),
+                        Paths.get("r/container/path"),
+                        ExecutorOptions.CopyDirection.COPY_TO_CONTAINER);
+
+        // Then:
+        assertThat(
+                copy.toString(),
+                is(
+                        "DirectoryInfo[hostPath=r/host/path, containerPath=r/container/path,"
+                                + " direction=COPY_TO_CONTAINER]"));
     }
 }

--- a/executor/src/test/java/org/creekservice/api/system/test/executor/SystemTestExecutorFunctionalTest.java
+++ b/executor/src/test/java/org/creekservice/api/system/test/executor/SystemTestExecutorFunctionalTest.java
@@ -639,6 +639,9 @@ class SystemTestExecutorFunctionalTest {
             cmd.addAll(remoteDebugArguments());
         }
         codeCoverageCmdLineArg().ifPresent(cmd::add);
+        // Docker Desktop >= 4.58.0 requires API version >= 1.44 (MinAPIVersion: 1.44).
+        // This can be removed once TestContainers is updated to 2.x
+        cmd.add("-Dapi.version=1.44");
 
         cmd.addAll(List.of(javaArgs));
         cmd.addAll(List.of(cmdArgs));

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/component/definition/ComponentDefinitionsTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/component/definition/ComponentDefinitionsTest.java
@@ -38,7 +38,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.creekservice.api.platform.metadata.AggregateDescriptor;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
@@ -216,7 +215,7 @@ class ComponentDefinitionsTest {
                 .filter(m -> !m.getDeclaringClass().equals(Object.class))
                 .filter(m -> !Modifier.isStatic(m.getModifiers()))
                 .map(Method::toGenericString)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 
     @ParameterizedTest(name = "[" + INDEX_PLACEHOLDER + "] {0}")

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/listener/TestListenersTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/listener/TestListenersTest.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
 import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.creekservice.api.system.test.extension.test.env.listener.TestEnvironmentListener;
 import org.junit.jupiter.api.BeforeEach;
@@ -148,6 +147,6 @@ class TestListenersTest {
                 .filter(m -> !m.getDeclaringClass().equals(Object.class))
                 .filter(m -> !Modifier.isStatic(m.getModifiers()))
                 .map(Method::toGenericString)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerFactoryTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerFactoryTest.java
@@ -18,9 +18,14 @@ package org.creekservice.internal.system.test.executor.api.test.env.suite.servic
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
@@ -37,43 +42,50 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.creekservice.api.system.test.executor.ExecutorOptions;
+import org.creekservice.api.system.test.executor.ExecutorOptions.CopyDirection;
+import org.creekservice.internal.system.test.executor.api.test.env.suite.service.ContainerFactory.CreatedContainer;
 import org.creekservice.internal.system.test.executor.execution.debug.ServiceDebugInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 @SuppressWarnings("resource")
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = LENIENT)
 class ContainerFactoryTest {
 
-    private static final Path HOST_PATH = Paths.get("host/path");
     private static final Path CONTAINER_PATH = Paths.get("container/path");
     private static final DockerImageName IMAGE_NAME =
             DockerImageName.parse("ghcr.io/creek-service/creek-system-test-test-service:latest");
     private static final int BASE_SERVICE_DEBUG_PORT = 9000;
     private static final String SERVICE_NAME = "bob";
     private static final String INSTANCE_NAME = "bob:1";
+    @TempDir Path hostDir;
     @Mock private ServiceDebugInfo serviceDebugInfo;
     @Mock private RegularContainerFactory regularFactory;
     @Mock private Supplier<Network> networkSupplier;
     @Mock private DebugContainerFactory debugFactory;
     @Mock private GenericContainer<?> container;
-    @Mock private ExecutorOptions.MountInfo mount;
+    @Mock private ExecutorOptions.DirectoryInfo mount;
     @Mock private Network network0;
     @Mock private Network network1;
+    @Captor private ArgumentCaptor<MountableFile> mountableCaptor;
 
     private ContainerFactory containerFactory;
 
@@ -96,10 +108,11 @@ class ContainerFactoryTest {
         doReturn(container).when(container).withNetwork(any());
         doReturn(container).when(container).withNetworkAliases(any());
         doReturn(container).when(container).withLogConsumer(any());
+        doReturn(container).when(container).withCopyFileToContainer(any(), any());
 
-        when(mount.hostPath()).thenReturn(HOST_PATH);
+        when(mount.hostPath()).thenReturn(hostDir);
         when(mount.containerPath()).thenReturn(CONTAINER_PATH);
-        when(mount.readOnly()).thenReturn(true);
+        when(mount.direction()).thenReturn(CopyDirection.COPY_TO_CONTAINER);
     }
 
     @Test
@@ -117,13 +130,14 @@ class ContainerFactoryTest {
         when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(false);
 
         // When:
-        final GenericContainer<?> result =
+        final CreatedContainer result =
                 containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, serviceUnderTest);
 
         // Then:
         verify(regularFactory).create(IMAGE_NAME);
         verify(debugFactory, never()).create(any(), anyInt());
-        assertThat(result, is(container));
+        assertThat(result.container(), is(container));
+        assertThat(result.transferables(), is(empty()));
     }
 
     @ValueSource(booleans = {true, false})
@@ -133,13 +147,13 @@ class ContainerFactoryTest {
         when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(true);
 
         // When:
-        final GenericContainer<?> result =
+        final CreatedContainer result =
                 containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, serviceUnderTest);
 
         // Then:
         verify(debugFactory).create(IMAGE_NAME, BASE_SERVICE_DEBUG_PORT);
         verify(regularFactory, never()).create(any());
-        assertThat(result, is(container));
+        assertThat(result.container(), is(container));
     }
 
     @ValueSource(booleans = {true, false})
@@ -442,7 +456,7 @@ class ContainerFactoryTest {
 
     @ValueSource(booleans = {true, false})
     @ParameterizedTest
-    void shouldSetMountsOnServicesUnderTest(final boolean debug) {
+    void shouldCopyDirectoriesIntoServicesUnderTest(final boolean debug) {
         // Given:
         containerFactory =
                 new ContainerFactory(
@@ -459,12 +473,13 @@ class ContainerFactoryTest {
 
         // Then:
         verify(container)
-                .withFileSystemBind(
-                        HOST_PATH.toString(), CONTAINER_PATH.toString(), BindMode.READ_ONLY);
+                .withCopyFileToContainer(mountableCaptor.capture(), eq(CONTAINER_PATH + "/"));
+        final MountableFile hostFile = mountableCaptor.getValue();
+        assertThat(hostFile.getResolvedPath(), is(hostDir.toAbsolutePath().toString()));
     }
 
     @Test
-    void shouldSetMountsOn3rdPartyServiceIfDebugging() {
+    void shouldCopyDirectoriesInto3rdPartyServiceIfDebugging() {
         // Given:
         containerFactory =
                 new ContainerFactory(
@@ -482,12 +497,13 @@ class ContainerFactoryTest {
 
         // Then:
         verify(container)
-                .withFileSystemBind(
-                        HOST_PATH.toString(), CONTAINER_PATH.toString(), BindMode.READ_ONLY);
+                .withCopyFileToContainer(mountableCaptor.capture(), eq(CONTAINER_PATH + "/"));
+        final MountableFile hostFile = mountableCaptor.getValue();
+        assertThat(hostFile.getResolvedPath(), is(hostDir.toAbsolutePath().toString()));
     }
 
     @Test
-    void shouldNotSetMountsOn3rdPartyServiceIfNotDebugging() {
+    void shouldNotCopyMountsInto3rdPartyServiceIfNotDebugging() {
         // Given:
         containerFactory =
                 new ContainerFactory(
@@ -500,15 +516,36 @@ class ContainerFactoryTest {
         when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(false);
 
         // When:
-        containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, false);
+        final CreatedContainer result =
+                containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, false);
 
         // Then:
-        verify(container, never()).withFileSystemBind(any(), any());
-        verify(container, never()).withFileSystemBind(any(), any(), any());
+        verify(container, never()).withCopyFileToContainer(any(), any());
+        assertThat(result.transferables(), is(empty()));
     }
 
     @Test
-    void shouldSetWritableMountsToo() {
+    void shouldThrowIfTransferableDoesNotExist() {
+        // Given:
+        final Path nonExistentPath = hostDir.resolve("does-not-exist");
+        when(mount.hostPath()).thenReturn(nonExistentPath);
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(mount),
+                        Map.of(),
+                        regularFactory,
+                        debugFactory,
+                        networkSupplier);
+
+        // When / Then:
+        assertThrows(
+                Exception.class,
+                () -> containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, true));
+    }
+
+    @Test
+    void shouldNotReturnTransferablesThatAreFullyActioned() {
         // Given:
         containerFactory =
                 new ContainerFactory(
@@ -518,14 +555,78 @@ class ContainerFactoryTest {
                         regularFactory,
                         debugFactory,
                         networkSupplier);
-        when(mount.readOnly()).thenReturn(false);
+        when(mount.direction()).thenReturn(CopyDirection.COPY_TO_CONTAINER);
+
+        // When:
+        final CreatedContainer result =
+                containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, true);
+
+        // Then:
+        assertThat(result.transferables(), not(hasItem(mount)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = CopyDirection.class,
+            names = {"COPY_FROM_CONTAINER", "COPY_TO_AND_FROM_CONTAINER"})
+    void shouldReturnTransferablesThatNeedActioning(final CopyDirection direction) {
+        // Given:
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(mount),
+                        Map.of(),
+                        regularFactory,
+                        debugFactory,
+                        networkSupplier);
+        when(mount.direction()).thenReturn(direction);
+
+        // When:
+        final CreatedContainer result =
+                containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, true);
+
+        // Then:
+        assertThat(result.transferables(), hasItem(mount));
+    }
+
+    @Test
+    void shouldNotCopyToContainerWhenDirectionIsCopyFromContainer() {
+        // Given:
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(mount),
+                        Map.of(),
+                        regularFactory,
+                        debugFactory,
+                        networkSupplier);
+        when(mount.direction()).thenReturn(CopyDirection.COPY_FROM_CONTAINER);
 
         // When:
         containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, true);
 
         // Then:
-        verify(container)
-                .withFileSystemBind(
-                        HOST_PATH.toString(), CONTAINER_PATH.toString(), BindMode.READ_WRITE);
+        verify(container, never()).withCopyFileToContainer(any(), any());
+    }
+
+    @Test
+    void shouldReturnCopyFromContainerInWritableCopies() {
+        // Given:
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(mount),
+                        Map.of(),
+                        regularFactory,
+                        debugFactory,
+                        networkSupplier);
+        when(mount.direction()).thenReturn(CopyDirection.COPY_FROM_CONTAINER);
+
+        // When:
+        final CreatedContainer result =
+                containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, true);
+
+        // Then:
+        assertThat(result.transferables(), hasItem(mount));
     }
 }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstanceTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstanceTest.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.params.ParameterizedInvocationConstants.INDEX_PL
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.clearInvocations;
@@ -39,6 +41,7 @@ import com.google.common.testing.NullPointerTester;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,10 +50,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.creekservice.api.base.type.RuntimeIOException;
 import org.creekservice.api.platform.metadata.ServiceDescriptor;
+import org.creekservice.api.system.test.executor.ExecutorOptions.DirectoryInfo;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ConfigurableServiceInstance;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ServiceInstance;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,15 +69,21 @@ import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.ThrowingFunction;
 
 @ExtendWith(MockitoExtension.class)
 class ContainerInstanceTest {
 
     private static final DockerImageName IMAGE_NAME =
             DockerImageName.parse("ghcr.io/creek-service/creek-system-test-test-service:latest");
+    private static final Path CONTAINER_PATH = Path.of("/opt/container/path");
+    private static final Path HOST_PATH = Path.of("/tmp/host/path");
 
     @Mock(answer = RETURNS_DEEP_STUBS, strictness = LENIENT)
     private GenericContainer<?> container;
+
+    @Mock(strictness = LENIENT)
+    private DirectoryInfo transferables;
 
     @Mock private ServiceDescriptor descriptor;
     @Mock private Consumer<ServiceInstance> startedCallback;
@@ -84,9 +93,17 @@ class ContainerInstanceTest {
 
     @BeforeEach
     void setUp() {
+        when(transferables.containerPath()).thenReturn(CONTAINER_PATH);
+        when(transferables.hostPath()).thenReturn(HOST_PATH);
+
         instance =
                 new ContainerInstance(
-                        "a-0", IMAGE_NAME, container, Optional.empty(), startedCallback);
+                        "a-0",
+                        IMAGE_NAME,
+                        container,
+                        Optional.empty(),
+                        startedCallback,
+                        List.of(transferables));
     }
 
     @Test
@@ -121,7 +138,8 @@ class ContainerInstanceTest {
                                 IMAGE_NAME,
                                 container,
                                 Optional.of(descriptor),
-                                startedCallback)
+                                startedCallback,
+                                List.of())
                         .descriptor(),
                 is(Optional.of(descriptor)));
     }
@@ -545,6 +563,7 @@ class ContainerInstanceTest {
                         container,
                         Optional.empty(),
                         startedCallback,
+                        List.of(),
                         Thread.currentThread().getId() + 1);
 
         // Then:
@@ -604,6 +623,33 @@ class ContainerInstanceTest {
                 hasSize(methodNames.size()));
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldCopyTransferablesFromContainerOnStop() {
+        // Given:
+        givenRunning();
+
+        // When:
+        instance.stop();
+
+        // Then:
+        verify(container)
+                .copyFileFromContainer(eq(CONTAINER_PATH.toString()), any(ThrowingFunction.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldThrowIfCopyFromContainerFails() {
+        // Given:
+        givenRunning();
+        doThrow(new RuntimeException("copy failed"))
+                .when(container)
+                .copyFileFromContainer(anyString(), any(ThrowingFunction.class));
+
+        // When / Then:
+        assertThrows(RuntimeException.class, instance::stop);
+    }
+
     private void givenRunning() {
         when(container.isRunning()).thenReturn(true);
         when(container.getContainerId()).thenReturn("bob");
@@ -649,7 +695,7 @@ class ContainerInstanceTest {
     }
 
     private static List<String> testedMethodNames() {
-        return methods().map(a -> (String) a.get()[0]).collect(Collectors.toUnmodifiableList());
+        return methods().map(a -> (String) a.get()[0]).toList();
     }
 
     private List<String> methodNames() {
@@ -658,7 +704,7 @@ class ContainerInstanceTest {
                 .filter(m -> !m.isSynthetic())
                 .filter(m -> !Modifier.isStatic(m.getModifiers()))
                 .map(Method::getName)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 
     public static Stream<Arguments> configureMethods() {
@@ -693,16 +739,14 @@ class ContainerInstanceTest {
     }
 
     private static List<String> testedConfigureMethodNames() {
-        return configureMethods()
-                .map(a -> (String) a.get()[0])
-                .collect(Collectors.toUnmodifiableList());
+        return configureMethods().map(a -> (String) a.get()[0]).toList();
     }
 
     private List<String> configureMethodNames() {
         return Arrays.stream(ConfigurableServiceInstance.class.getDeclaredMethods())
                 .filter(m -> !m.isSynthetic())
                 .map(Method::getName)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 
     private static List<String> notTested(final List<String> all, final List<String> tested) {

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/DockerServiceContainerFunctionalTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/DockerServiceContainerFunctionalTest.java
@@ -46,6 +46,7 @@ import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.InternetProtocol;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -57,7 +58,8 @@ import java.util.Random;
 import java.util.regex.Pattern;
 import org.creekservice.api.observability.lifecycle.BasicLifecycle;
 import org.creekservice.api.platform.metadata.ServiceDescriptor;
-import org.creekservice.api.system.test.executor.ExecutorOptions.MountInfo;
+import org.creekservice.api.system.test.executor.ExecutorOptions.CopyDirection;
+import org.creekservice.api.system.test.executor.ExecutorOptions.DirectoryInfo;
 import org.creekservice.api.system.test.extension.component.definition.ServiceDefinition;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ConfigurableServiceInstance;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ServiceInstance;
@@ -73,6 +75,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -341,12 +344,12 @@ class DockerServiceContainerFunctionalTest {
     void shouldSetEnvOnInstanceUnderTest(final boolean debug) {
         // Given:
         givenServiceUnderTest();
-        instances =
-                new DockerServiceContainer(
-                        new ContainerFactory(
-                                serviceDebugInfo,
-                                List.of(),
-                                Map.of("CREEK_TEST_ENV_KEY", "expected value")));
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(),
+                        Map.of("CREEK_TEST_ENV_KEY", "expected value"));
+        instances = new DockerServiceContainer(containerFactory);
         when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(debug);
         final ServiceInstance instance = instances.add(serviceDef);
 
@@ -363,12 +366,12 @@ class DockerServiceContainerFunctionalTest {
     @ParameterizedTest
     void shouldNotSetEnvOn3rdPartyInstance(final boolean debug) {
         // Given:
-        instances =
-                new DockerServiceContainer(
-                        new ContainerFactory(
-                                serviceDebugInfo,
-                                List.of(),
-                                Map.of("CREEK_TEST_ENV_KEY", "expected value")));
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(),
+                        Map.of("CREEK_TEST_ENV_KEY", "expected value"));
+        instances = new DockerServiceContainer(containerFactory);
         when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(debug);
         final ServiceInstance instance = instances.add(serviceDef);
 
@@ -388,12 +391,12 @@ class DockerServiceContainerFunctionalTest {
         if (serviceUnderTest) {
             givenServiceUnderTest();
         }
-        instances =
-                new DockerServiceContainer(
-                        new ContainerFactory(
-                                serviceDebugInfo,
-                                List.of(),
-                                Map.of("CREEK_TEST_ENV_KEY", "original value")));
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(),
+                        Map.of("CREEK_TEST_ENV_KEY", "original value"));
+        instances = new DockerServiceContainer(containerFactory);
         when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(true);
         when(serviceDebugInfo.env()).thenReturn(Map.of("CREEK_TEST_ENV_KEY", "expected value"));
         final ServiceInstance instance = instances.add(serviceDef);
@@ -406,17 +409,20 @@ class DockerServiceContainerFunctionalTest {
                 hasItem("CREEK_TEST_ENV_KEY=expected value"));
     }
 
-    @Test
-    void shouldSetReadOnlyMountOnInstanceUnderTest() {
+    @ParameterizedTest
+    @EnumSource(
+            value = CopyDirection.class,
+            names = {"COPY_TO_CONTAINER", "COPY_TO_AND_FROM_CONTAINER"})
+    void shouldCopyDirectoryIntoInstanceUnderTest(final CopyDirection direction) {
         // Given:
         givenServiceUnderTest();
         TestPaths.write(tmpDir.resolve("some.file"), "data");
-        instances =
-                new DockerServiceContainer(
-                        new ContainerFactory(
-                                serviceDebugInfo,
-                                List.of(mount(tmpDir, Paths.get("/opt/creek/test_mount"), true)),
-                                Map.of()));
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(directory(tmpDir, Paths.get("/opt/creek/test_mount"), direction)),
+                        Map.of());
+        instances = new DockerServiceContainer(containerFactory);
         final ServiceInstance instance = instances.add(serviceDef);
         final int start = (int) System.currentTimeMillis() / 1000;
 
@@ -426,45 +432,106 @@ class DockerServiceContainerFunctionalTest {
         // Then:
         final StringBuilder instanceLogs = trackContainerLogs(instance, start);
         assertThatEventually(instanceLogs::toString, containsString("some.file : present"));
-
         assertThatEventually(
-                instanceLogs::toString, containsString("/opt/creek/test_mount : read-only"));
+                instanceLogs::toString, containsString("/opt/creek/test_mount : directory"));
     }
 
     @Test
-    void shouldSetWritableMountOnInstanceUnderTest() {
+    void shouldNotCopyDirectoryBackToHostWhenNotInstructedTo() {
         // Given:
         givenServiceUnderTest();
         TestPaths.write(tmpDir.resolve("some.file"), "data");
-        instances =
-                new DockerServiceContainer(
-                        new ContainerFactory(
-                                serviceDebugInfo,
-                                List.of(mount(tmpDir, Paths.get("/opt/creek/test_mount"), false)),
-                                Map.of()));
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(
+                                directory(
+                                        tmpDir,
+                                        Paths.get("/opt/creek/test_mount"),
+                                        CopyDirection.COPY_TO_CONTAINER)),
+                        Map.of());
+        instances = new DockerServiceContainer(containerFactory);
+        final ServiceInstance instance = instances.add(serviceDef);
+
+        // When:
+        instance.start();
+        instance.stop();
+
+        // Then:
+        assertThat(tmpDir.resolve("some/dir/container.file").toFile().exists(), is(false));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = CopyDirection.class,
+            names = {"COPY_FROM_CONTAINER", "COPY_TO_AND_FROM_CONTAINER"})
+    void shouldCopyDirectoryFromHostAfterStop(final CopyDirection direction) throws Exception {
+        // Given:
+        givenServiceUnderTest();
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(directory(tmpDir, Paths.get("/opt/creek/test_mount"), direction)),
+                        Map.of());
+        instances = new DockerServiceContainer(containerFactory);
         final ServiceInstance instance = instances.add(serviceDef);
         final int start = (int) System.currentTimeMillis() / 1000;
 
         // When:
         instance.start();
+        final StringBuilder instanceLogs = trackContainerLogs(instance, start);
+        assertThatEventually(
+                instanceLogs::toString, containsString("some/dir/container.file : written"));
+        instance.stop();
 
         // Then:
-        final StringBuilder instanceLogs = trackContainerLogs(instance, start);
-        assertThatEventually(instanceLogs::toString, containsString("some.file : present"));
+        assertThat(Files.isRegularFile(tmpDir.resolve("some/dir/container.file")), is(true));
+        assertThat(
+                Files.readString(tmpDir.resolve("some/dir/container.file")),
+                is("written-by-container"));
+    }
 
+    @Test
+    void shouldNotCopyDirectoryFromHostAfterStopIfNotInstructedTo() {
+        // Given:
+        givenServiceUnderTest();
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(
+                                directory(
+                                        tmpDir,
+                                        Paths.get("/opt/creek/test_mount"),
+                                        CopyDirection.COPY_TO_CONTAINER)),
+                        Map.of());
+        instances = new DockerServiceContainer(containerFactory);
+        final ServiceInstance instance = instances.add(serviceDef);
+        final int start = (int) System.currentTimeMillis() / 1000;
+
+        // When:
+        instance.start();
+        final StringBuilder instanceLogs = trackContainerLogs(instance, start);
         assertThatEventually(
-                instanceLogs::toString, containsString("/opt/creek/test_mount : writable"));
+                instanceLogs::toString, containsString("some/dir/container.file : written"));
+        instance.stop();
+
+        // Then:
+        assertThat(Files.exists(tmpDir.resolve("some/dir/container.file")), is(false));
     }
 
     @Test
     void shouldNotSetMountsOn3rdPartyInstances() {
         // Given:
-        instances =
-                new DockerServiceContainer(
-                        new ContainerFactory(
-                                serviceDebugInfo,
-                                List.of(mount(tmpDir, Paths.get("/opt/creek/test_mount"), false)),
-                                Map.of()));
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(
+                                directory(
+                                        tmpDir,
+                                        Paths.get("/opt/creek/test_mount"),
+                                        CopyDirection.COPY_TO_AND_FROM_CONTAINER)),
+                        Map.of());
+        instances = new DockerServiceContainer(containerFactory);
         final ServiceInstance instance = instances.add(serviceDef);
         final int start = (int) System.currentTimeMillis() / 1000;
 
@@ -480,12 +547,16 @@ class DockerServiceContainerFunctionalTest {
     @Test
     void shouldNotSetMountsOn3rdPartyInstancesUnlessDebuggingThem() {
         // Given:
-        instances =
-                new DockerServiceContainer(
-                        new ContainerFactory(
-                                serviceDebugInfo,
-                                List.of(mount(tmpDir, Paths.get("/opt/creek/test_mount"), false)),
-                                Map.of()));
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(
+                                directory(
+                                        tmpDir,
+                                        Paths.get("/opt/creek/test_mount"),
+                                        CopyDirection.COPY_TO_AND_FROM_CONTAINER)),
+                        Map.of());
+        instances = new DockerServiceContainer(containerFactory);
         TestPaths.write(tmpDir.resolve("some.file"), "data");
         when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(true);
         final ServiceInstance instance = instances.add(serviceDef);
@@ -497,9 +568,8 @@ class DockerServiceContainerFunctionalTest {
         // Then:
         final StringBuilder instanceLogs = trackContainerLogs(instance, start);
         assertThatEventually(instanceLogs::toString, containsString("some.file : present"));
-
         assertThatEventually(
-                instanceLogs::toString, containsString("/opt/creek/test_mount : writable"));
+                instanceLogs::toString, containsString("/opt/creek/test_mount : directory"));
     }
 
     @Test
@@ -630,13 +700,13 @@ class DockerServiceContainerFunctionalTest {
         };
     }
 
-    private static MountInfo mount(
-            final Path hostPath, final Path containerPath, final boolean readOnly) {
-        final MountInfo mount =
-                mock(MountInfo.class, withSettings().strictness(Strictness.LENIENT));
+    private static DirectoryInfo directory(
+            final Path hostPath, final Path containerPath, final CopyDirection direction) {
+        final DirectoryInfo mount =
+                mock(DirectoryInfo.class, withSettings().strictness(Strictness.LENIENT));
         when(mount.hostPath()).thenReturn(hostPath);
         when(mount.containerPath()).thenReturn(containerPath);
-        when(mount.readOnly()).thenReturn(readOnly);
+        when(mount.direction()).thenReturn(direction);
         return mount;
     }
 

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/DockerServiceContainerTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/DockerServiceContainerTest.java
@@ -42,12 +42,12 @@ import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.creekservice.api.platform.metadata.ServiceDescriptor;
 import org.creekservice.api.system.test.extension.component.definition.ServiceDefinition;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ConfigurableServiceInstance;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ServiceInstance;
+import org.creekservice.internal.system.test.executor.api.test.env.suite.service.ContainerFactory.CreatedContainer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,7 +76,6 @@ class DockerServiceContainerTest {
 
     private DockerServiceContainer instances;
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @BeforeEach
     void setUp() {
         instances = new DockerServiceContainer(containerFactory);
@@ -84,7 +83,7 @@ class DockerServiceContainerTest {
         when(serviceDef.name()).thenReturn(SERVICE_NAME);
         when(serviceDef.dockerImage()).thenReturn(IMAGE_NAME.toString());
         when(containerFactory.create(any(), any(), any(), anyBoolean()))
-                .thenReturn((GenericContainer) container);
+                .thenReturn(new CreatedContainer(container, List.of()));
     }
 
     @Test
@@ -258,9 +257,7 @@ class DockerServiceContainerTest {
     }
 
     private static List<String> testedMethodNames() {
-        return publicMethods()
-                .map(a -> (String) a.get()[0])
-                .collect(Collectors.toUnmodifiableList());
+        return publicMethods().map(a -> (String) a.get()[0]).toList();
     }
 
     private List<String> publicMethodNames() {
@@ -268,6 +265,6 @@ class DockerServiceContainerTest {
                 .filter(m -> !m.getDeclaringClass().equals(Object.class))
                 .filter(m -> !Modifier.isStatic(m.getModifiers()))
                 .map(Method::toGenericString)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/model/TestModelTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/model/TestModelTest.java
@@ -32,7 +32,6 @@ import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.creekservice.api.system.test.extension.test.model.Expectation;
 import org.creekservice.api.system.test.extension.test.model.ExpectationHandler;
@@ -274,7 +273,7 @@ class TestModelTest {
                 .filter(m -> !m.getDeclaringClass().equals(Object.class))
                 .filter(m -> !Modifier.isStatic(m.getModifiers()))
                 .map(Method::toGenericString)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 
     private static final class TestRef implements InputRef, ExpectationRef {

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
@@ -351,12 +351,13 @@ class PicoCliParserTest {
 
         // Then:
         assertThat(
-                result.map(ExecutorOptions::mountInfo).map(Collection::size), is(Optional.of(1)));
+                result.map(ExecutorOptions::transferables).map(Collection::size),
+                is(Optional.of(1)));
 
-        final ExecutorOptions.MountInfo mount = result.get().mountInfo().iterator().next();
+        final ExecutorOptions.DirectoryInfo mount = result.get().transferables().iterator().next();
         assertThat(mount.hostPath(), is(mountSource));
         assertThat(mount.containerPath(), is(mountDestination));
-        assertThat(mount.readOnly(), is(true));
+        assertThat(mount.direction(), is(ExecutorOptions.CopyDirection.COPY_TO_CONTAINER));
     }
 
     @Test
@@ -369,12 +370,13 @@ class PicoCliParserTest {
 
         // Then:
         assertThat(
-                result.map(ExecutorOptions::mountInfo).map(Collection::size), is(Optional.of(1)));
+                result.map(ExecutorOptions::transferables).map(Collection::size),
+                is(Optional.of(1)));
 
-        final ExecutorOptions.MountInfo mount = result.get().mountInfo().iterator().next();
+        final ExecutorOptions.DirectoryInfo mount = result.get().transferables().iterator().next();
         assertThat(mount.hostPath(), is(Path.of("host/path")));
         assertThat(mount.containerPath(), is(Path.of("container/path")));
-        assertThat(mount.readOnly(), is(false));
+        assertThat(mount.direction(), is(ExecutorOptions.CopyDirection.COPY_TO_AND_FROM_CONTAINER));
     }
 
     @Test
@@ -392,7 +394,8 @@ class PicoCliParserTest {
 
         // Then:
         assertThat(
-                result.map(ExecutorOptions::mountInfo).map(Collection::size), is(Optional.of(4)));
+                result.map(ExecutorOptions::transferables).map(Collection::size),
+                is(Optional.of(4)));
     }
 
     @Test
@@ -574,8 +577,8 @@ class PicoCliParserTest {
                         "-dsi=a-0,b-1",
                         "-de=E=F",
                         "-e=A=B,C=D",
-                        "-mr=" + mrS0 + "=" + mrD0 + "," + mrS1 + "=" + mrD1,
-                        "-mw=" + mwS0 + "=" + mwD0 + "," + mwS1 + "=" + mwD1);
+                        "--dir-copy-read-only=" + mrS0 + "=" + mrD0 + "," + mrS1 + "=" + mrD1,
+                        "--dir-copy-read-write=" + mwS0 + "=" + mwD0 + "," + mwS1 + "=" + mwD1);
 
         // When:
         final Optional<ExecutorOptions> result = parse(args);

--- a/extension/src/main/java/org/creekservice/api/system/test/extension/CreekTestExtensions.java
+++ b/extension/src/main/java/org/creekservice/api/system/test/extension/CreekTestExtensions.java
@@ -18,7 +18,6 @@ package org.creekservice.api.system.test.extension;
 
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.stream.Collectors;
 
 /** Factory class for loading system test extensions. */
 public final class CreekTestExtensions {
@@ -33,6 +32,6 @@ public final class CreekTestExtensions {
     public static List<CreekTestExtension> load() {
         return ServiceLoader.load(CreekTestExtension.class).stream()
                 .map(ServiceLoader.Provider::get)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 }

--- a/extension/src/test/java/org/creekservice/api/system/test/extension/test/env/listener/TestEnvironmentListenerTest.java
+++ b/extension/src/test/java/org/creekservice/api/system/test/extension/test/env/listener/TestEnvironmentListenerTest.java
@@ -27,7 +27,6 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.creekservice.api.system.test.extension.test.model.CreekTestCase;
 import org.creekservice.api.system.test.extension.test.model.CreekTestSuite;
@@ -98,6 +97,6 @@ class TestEnvironmentListenerTest {
                 .filter(m -> !m.getDeclaringClass().equals(Object.class))
                 .filter(m -> !Modifier.isStatic(m.getModifiers()))
                 .map(Method::toGenericString)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 }

--- a/model/src/main/java/org/creekservice/api/system/test/model/TestPackage.java
+++ b/model/src/main/java/org/creekservice/api/system/test/model/TestPackage.java
@@ -22,7 +22,6 @@ import static org.creekservice.api.base.type.Preconditions.requireNonEmpty;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.creekservice.api.system.test.extension.test.model.Input;
 
 /** A package to seed data and test suites. */
@@ -49,7 +48,7 @@ public final class TestPackage {
         this.suites =
                 requireNonEmpty(suites, "suites").stream()
                         .map(builder -> builder.build(this))
-                        .collect(Collectors.toUnmodifiableList());
+                        .toList();
     }
 
     /**

--- a/model/src/main/java/org/creekservice/api/system/test/model/TestSuite.java
+++ b/model/src/main/java/org/creekservice/api/system/test/model/TestSuite.java
@@ -55,7 +55,7 @@ public final class TestSuite implements CreekTestSuite {
         this.tests =
                 requireNonNull(tests, "tests").stream()
                         .map(builder -> builder.build(this))
-                        .collect(Collectors.toUnmodifiableList());
+                        .toList();
 
         requireEqual(tests.size(), def.tests().size(), "test case size mismatch");
     }

--- a/parser/src/main/java/org/creekservice/internal/system/test/parser/YamlTestPackageParser.java
+++ b/parser/src/main/java/org/creekservice/internal/system/test/parser/YamlTestPackageParser.java
@@ -110,7 +110,7 @@ public final class YamlTestPackageParser implements TestPackageParser {
                 loadDir(path, TestSuiteDef.class)
                         .filter(f -> predicate.test(f.path()))
                         .map(f -> testSuiteBuilder(f.content(), inputs, expectations))
-                        .collect(Collectors.toUnmodifiableList());
+                        .toList();
 
         if (suites.isEmpty()) {
             return Optional.empty();
@@ -132,9 +132,7 @@ public final class YamlTestPackageParser implements TestPackageParser {
         }
 
         try (Stream<Path> stream = Files.walk(dir, 1)) {
-            return stream.filter(Files::isRegularFile)
-                    .filter(YAML_MATCHER::matches)
-                    .collect(Collectors.toUnmodifiableList());
+            return stream.filter(Files::isRegularFile).filter(YAML_MATCHER::matches).toList();
         } catch (final IOException e) {
             throw new TestLoadFailedException("Error accessing directory " + dir, e);
         }
@@ -204,7 +202,7 @@ public final class YamlTestPackageParser implements TestPackageParser {
                         .filter(LazyFile::unused)
                         .map(LazyFile::path)
                         .map(Path::toAbsolutePath)
-                        .collect(Collectors.toUnmodifiableList());
+                        .toList();
 
         if (!unused.isEmpty()) {
             observer.unusedDependencies(path, unused);

--- a/test-service/src/main/java/org/creekservice/internal/system/test/test/service/ServiceMain.java
+++ b/test-service/src/main/java/org/creekservice/internal/system/test/test/service/ServiceMain.java
@@ -54,21 +54,30 @@ public final class ServiceMain {
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     private static void logMount() {
         final Path mount = Paths.get("/opt/creek/test_mount");
-        if (!Files.isDirectory(mount)) {
-            LOGGER.info("/opt/creek/test_mount : not-present");
-            return;
-        }
-
-        if (Files.isWritable(mount)) {
-            LOGGER.info("/opt/creek/test_mount : writable");
+        if (Files.isDirectory(mount)) {
+            LOGGER.info("/opt/creek/test_mount : directory");
+        } else if (Files.isRegularFile(mount)) {
+            LOGGER.info("/opt/creek/test_mount : file");
         } else {
-            LOGGER.info("/opt/creek/test_mount : read-only");
+            LOGGER.info("/opt/creek/test_mount : not-present");
         }
 
         if (Files.isRegularFile(mount.resolve("some.file"))) {
             LOGGER.info("some.file : present");
         } else {
             LOGGER.info("some.file : not-present");
+        }
+
+        try {
+            final Path path = mount.resolve("some/dir/container.file");
+            final Path parent = path.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            Files.writeString(path, "written-by-container");
+            LOGGER.info("some/dir/container.file : written");
+        } catch (final Exception e) {
+            LOGGER.info("some/dir/container.file : write-failed", e);
         }
     }
 

--- a/test-util/src/main/java/org/creekservice/api/system/test/test/util/CreekSystemTestExtensionTester.java
+++ b/test-util/src/main/java/org/creekservice/api/system/test/test/util/CreekSystemTestExtensionTester.java
@@ -22,19 +22,17 @@ import static org.creekservice.internal.system.test.executor.execution.debug.Ser
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.api.platform.metadata.ComponentDescriptors;
 import org.creekservice.api.system.test.executor.ExecutorOptions;
-import org.creekservice.api.system.test.executor.ExecutorOptions.MountInfo;
+import org.creekservice.api.system.test.executor.ExecutorOptions.DirectoryInfo;
 import org.creekservice.api.system.test.extension.CreekTestExtension;
 import org.creekservice.api.system.test.extension.CreekTestExtensions;
 import org.creekservice.api.system.test.extension.component.definition.AggregateDefinition;
@@ -58,7 +56,7 @@ public final class CreekSystemTestExtensionTester {
     private final ComponentDefinitions<ServiceDefinition> serviceDefinitions;
     private final ComponentDefinitions<AggregateDefinition> aggregateDefinitions;
     private final ServiceDebugInfo serviceDebugInfo;
-    private final List<MountInfo> mountInfo;
+    private final List<DirectoryInfo> fileCopies;
     private final Map<String, String> env;
 
     /**
@@ -66,19 +64,6 @@ public final class CreekSystemTestExtensionTester {
      */
     public static TesterBuilder tester() {
         return new TesterBuilder(ServiceDebugInfo.none(), List.of(), Map.of());
-    }
-
-    /**
-     * Define a {@link MountInfo mount}.
-     *
-     * @param hostPath the path to the directory to mount on the host machine.
-     * @param containerPath the path within the container the mount will be accessible.
-     * @param readOnly indicates if the mount should be read-only or mountable.
-     * @return the mount info.
-     */
-    public static MountInfo mount(
-            final Path hostPath, final Path containerPath, final boolean readOnly) {
-        return new Mount(hostPath, containerPath, readOnly);
     }
 
     /**
@@ -99,17 +84,17 @@ public final class CreekSystemTestExtensionTester {
             final ComponentDefinitions<ServiceDefinition> serviceDefinitions,
             final ComponentDefinitions<AggregateDefinition> aggregateDefinitions,
             final ServiceDebugInfo serviceDebugInfo,
-            final Collection<MountInfo> mountInfo,
+            final Collection<DirectoryInfo> fileCopies,
             final Map<String, String> env) {
         this.serviceDefinitions = requireNonNull(serviceDefinitions, "serviceDefinitions");
         this.aggregateDefinitions = requireNonNull(aggregateDefinitions, "aggregateDefinitions");
         this.serviceDebugInfo = requireNonNull(serviceDebugInfo, "serviceDebugInfo");
-        this.mountInfo = List.copyOf(requireNonNull(mountInfo, "mountInfo"));
+        this.fileCopies = List.copyOf(requireNonNull(fileCopies, "fileCopies"));
         this.env = Map.copyOf(requireNonNull(env, "env"));
 
         this.services =
                 new DockerServiceContainer(
-                        new ContainerFactory(this.serviceDebugInfo, this.mountInfo, this.env));
+                        new ContainerFactory(this.serviceDebugInfo, this.fileCopies, this.env));
     }
 
     /**
@@ -211,8 +196,8 @@ public final class CreekSystemTestExtensionTester {
         return serviceDebugInfo;
     }
 
-    List<MountInfo> mountInfo() {
-        return mountInfo;
+    List<DirectoryInfo> transferables() {
+        return fileCopies;
     }
 
     Map<String, String> env() {
@@ -223,15 +208,15 @@ public final class CreekSystemTestExtensionTester {
     public static final class TesterBuilder {
 
         private final ServiceDebugInfo serviceDebugInfo;
-        private final List<MountInfo> mountInfo;
+        private final List<DirectoryInfo> transferables;
         private final Map<String, String> env;
 
         private TesterBuilder(
                 final ServiceDebugInfo serviceDebugInfo,
-                final List<MountInfo> mountInfo,
+                final List<DirectoryInfo> transferables,
                 final Map<String, String> env) {
             this.serviceDebugInfo = requireNonNull(serviceDebugInfo, "serviceDebugInfo");
-            this.mountInfo = List.copyOf(requireNonNull(mountInfo, "mountInfo"));
+            this.transferables = List.copyOf(requireNonNull(transferables, "transferables"));
             this.env = Map.copyOf(requireNonNull(env, "env"));
         }
 
@@ -260,50 +245,28 @@ public final class CreekSystemTestExtensionTester {
          *     Debugging</a>
          */
         public TesterBuilder withDebugServices(final ExecutorOptions.ServiceDebugInfo debugInfo) {
-            return new TesterBuilder(ServiceDebugInfo.copyOf(debugInfo), mountInfo, env);
+            return new TesterBuilder(ServiceDebugInfo.copyOf(debugInfo), transferables, env);
         }
 
         /**
-         * Add a read-only mount.
+         * Add a file copy.
          *
-         * @param hostPath the path to the directory to mount on the host machine.
-         * @param containerPath the path within the container the mount will be accessible.
+         * @param fileCopy details of the file copy to add.
          * @return self
          */
-        public TesterBuilder withReadOnlyMount(final Path hostPath, final Path containerPath) {
-            return withMount(mount(hostPath, containerPath, true));
+        public TesterBuilder withDirectoryCopy(final DirectoryInfo fileCopy) {
+            return withDirectoryCopy(List.of(fileCopy));
         }
 
         /**
-         * Add a writable mount.
+         * Add file copies.
          *
-         * @param hostPath the path to the directory to mount on the host machine.
-         * @param containerPath the path within the container the mount will be accessible.
+         * @param copies details of the file copies to add.
          * @return self
          */
-        public TesterBuilder withWritableMount(final Path hostPath, final Path containerPath) {
-            return withMount(mount(hostPath, containerPath, false));
-        }
-
-        /**
-         * Add a mount.
-         *
-         * @param mount details of the mount to add. See {@link #mount(Path, Path, boolean)}.
-         * @return self
-         */
-        public TesterBuilder withMount(final MountInfo mount) {
-            return withMounts(List.of(mount));
-        }
-
-        /**
-         * Add mounts.
-         *
-         * @param mounts details of the mounts to add. See {@link #mount(Path, Path, boolean)}.
-         * @return self
-         */
-        public TesterBuilder withMounts(final Collection<? extends MountInfo> mounts) {
-            final List<MountInfo> all = new ArrayList<>(mountInfo);
-            all.addAll(mounts);
+        public TesterBuilder withDirectoryCopy(final Collection<? extends DirectoryInfo> copies) {
+            final List<DirectoryInfo> all = new ArrayList<>(transferables);
+            all.addAll(copies);
             return new TesterBuilder(serviceDebugInfo, all, env);
         }
 
@@ -327,7 +290,7 @@ public final class CreekSystemTestExtensionTester {
         public TesterBuilder withEnv(final Map<String, String> env) {
             final Map<String, String> all = new HashMap<>(this.env);
             all.putAll(env);
-            return new TesterBuilder(serviceDebugInfo, mountInfo, all);
+            return new TesterBuilder(serviceDebugInfo, transferables, all);
         }
 
         /**
@@ -342,7 +305,7 @@ public final class CreekSystemTestExtensionTester {
             final ComponentDefinitions<AggregateDefinition> aggregateDefinitions =
                     ComponentDefinitions.aggregateDefinitions(components);
             return new CreekSystemTestExtensionTester(
-                    serviceDefinitions, aggregateDefinitions, serviceDebugInfo, mountInfo, env);
+                    serviceDefinitions, aggregateDefinitions, serviceDebugInfo, transferables, env);
         }
     }
 
@@ -381,64 +344,6 @@ public final class CreekSystemTestExtensionTester {
                     return subType.cast(mapper.readValue(text, baseType));
                 }
             };
-        }
-    }
-
-    private static final class Mount implements MountInfo {
-        private final Path hostPath;
-        private final Path containerPath;
-        private final boolean readOnly;
-
-        private Mount(final Path hostPath, final Path containerPath, final boolean readOnly) {
-            this.hostPath = requireNonNull(hostPath, "hostPath");
-            this.containerPath = requireNonNull(containerPath, "containerPath");
-            this.readOnly = readOnly;
-        }
-
-        @Override
-        public Path hostPath() {
-            return hostPath;
-        }
-
-        @Override
-        public Path containerPath() {
-            return containerPath;
-        }
-
-        @Override
-        public boolean readOnly() {
-            return readOnly;
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            final Mount mount = (Mount) o;
-            return readOnly == mount.readOnly
-                    && Objects.equals(hostPath, mount.hostPath)
-                    && Objects.equals(containerPath, mount.containerPath);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(hostPath, containerPath, readOnly);
-        }
-
-        @Override
-        public String toString() {
-            return "Mount{"
-                    + "hostPath="
-                    + hostPath
-                    + ", containerPath="
-                    + containerPath
-                    + ", readOnly="
-                    + readOnly
-                    + '}';
         }
     }
 }

--- a/test-util/src/test/java/org/creekservice/api/system/test/test/util/CreekSystemTestExtensionTesterTest.java
+++ b/test-util/src/test/java/org/creekservice/api/system/test/test/util/CreekSystemTestExtensionTesterTest.java
@@ -17,7 +17,6 @@
 package org.creekservice.api.system.test.test.util;
 
 import static org.creekservice.api.system.test.executor.ExecutorOptions.ServiceDebugInfo.DEFAULT_BASE_DEBUG_PORT;
-import static org.creekservice.api.system.test.test.util.CreekSystemTestExtensionTester.mount;
 import static org.creekservice.internal.system.test.executor.execution.debug.ServiceDebugInfo.serviceDebugInfo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.blankOrNullString;
@@ -42,7 +41,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Set;
-import org.creekservice.api.system.test.executor.ExecutorOptions.MountInfo;
+import org.creekservice.api.system.test.executor.ExecutorOptions;
+import org.creekservice.api.system.test.executor.ExecutorOptions.DirectoryInfo;
 import org.creekservice.api.system.test.extension.component.definition.ServiceDefinition;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ServiceInstance;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ServiceInstanceContainer;
@@ -180,23 +180,33 @@ class CreekSystemTestExtensionTesterTest {
     }
 
     @Test
-    void shouldSupportMounts() {
+    void shouldSupportCopyingDirectories() {
         // Given:
         tester =
-                builder.withReadOnlyMount(Paths.get("r/host/path"), Paths.get("r/container/path"))
-                        .withWritableMount(Paths.get("w/host/path"), Paths.get("w/container/path"))
+                builder.withDirectoryCopy(
+                                new DirectoryInfo(
+                                        Paths.get("r/host/path"),
+                                        Paths.get("r/container/path"),
+                                        ExecutorOptions.CopyDirection.COPY_TO_CONTAINER))
+                        .withDirectoryCopy(
+                                new DirectoryInfo(
+                                        Paths.get("w/host/path"),
+                                        Paths.get("w/container/path"),
+                                        ExecutorOptions.CopyDirection.COPY_TO_AND_FROM_CONTAINER))
                         .build();
 
         // Then:
         assertThat(
-                tester.mountInfo(),
+                tester.transferables(),
                 contains(
-                        mount(Paths.get("r/host/path"), Paths.get("r/container/path"), true),
-                        mount(Paths.get("w/host/path"), Paths.get("w/container/path"), false)));
-
-        assertThat(tester.mountInfo().get(0).hostPath(), is(Path.of("r/host/path")));
-        assertThat(tester.mountInfo().get(0).containerPath(), is(Path.of("r/container/path")));
-        assertThat(tester.mountInfo().get(0).readOnly(), is(true));
+                        new DirectoryInfo(
+                                Paths.get("r/host/path"),
+                                Paths.get("r/container/path"),
+                                ExecutorOptions.CopyDirection.COPY_TO_CONTAINER),
+                        new DirectoryInfo(
+                                Paths.get("w/host/path"),
+                                Paths.get("w/container/path"),
+                                ExecutorOptions.CopyDirection.COPY_TO_AND_FROM_CONTAINER)));
     }
 
     @Test
@@ -301,27 +311,42 @@ class CreekSystemTestExtensionTesterTest {
 
     @Test
     void shouldImplementHashCodeAndEqualsOnMount() {
+        final Path hostPath = Paths.get("r/host/path");
+        final Path containerPath = Paths.get("r/container/path");
+        final Path hostPath1 = Paths.get("r/host/path");
+        final Path containerPath1 = Paths.get("diff");
+        final Path hostPath2 = Paths.get("diff");
+        final Path containerPath2 = Paths.get("r/container/path");
+        final Path hostPath3 = Paths.get("r/host/path");
+        final Path containerPath3 = Paths.get("r/container/path");
+        final Path hostPath4 = Paths.get("r/host/path");
+        final Path containerPath4 = Paths.get("r/container/path");
         new EqualsTester()
                 .addEqualityGroup(
-                        mount(Paths.get("r/host/path"), Paths.get("r/container/path"), true),
-                        mount(Paths.get("r/host/path"), Paths.get("r/container/path"), true))
-                .addEqualityGroup(mount(Paths.get("diff"), Paths.get("r/container/path"), true))
-                .addEqualityGroup(mount(Paths.get("r/host/path"), Paths.get("diff"), true))
+                        new DirectoryInfo(
+                                hostPath4,
+                                containerPath4,
+                                ExecutorOptions.CopyDirection.COPY_TO_CONTAINER),
+                        new DirectoryInfo(
+                                hostPath3,
+                                containerPath3,
+                                ExecutorOptions.CopyDirection.COPY_TO_CONTAINER))
                 .addEqualityGroup(
-                        mount(Paths.get("r/host/path"), Paths.get("r/container/path"), false))
+                        new DirectoryInfo(
+                                hostPath2,
+                                containerPath2,
+                                ExecutorOptions.CopyDirection.COPY_TO_CONTAINER))
+                .addEqualityGroup(
+                        new DirectoryInfo(
+                                hostPath1,
+                                containerPath1,
+                                ExecutorOptions.CopyDirection.COPY_TO_CONTAINER))
+                .addEqualityGroup(
+                        new DirectoryInfo(
+                                hostPath,
+                                containerPath,
+                                ExecutorOptions.CopyDirection.COPY_TO_AND_FROM_CONTAINER))
                 .testEquals();
-    }
-
-    @Test
-    void shouldToStringOnMount() {
-        // Given:
-        final MountInfo mount =
-                mount(Paths.get("r/host/path"), Paths.get("r/container/path"), true);
-
-        // Then:
-        assertThat(
-                mount.toString(),
-                is("Mount{hostPath=r/host/path, containerPath=r/container/path, readOnly=true}"));
     }
 
     public static final class TestRef implements InputRef, ExpectationRef {


### PR DESCRIPTION
TestContainers have deprecated `withFileSystemBind`. This change moves away from using binds and instead copies files into a container before it's started and out of the container after it's stopped, as needed.

This is a breaking change.
