### PR TITLE
chore: update buildSrc plugin versions

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -37,9 +37,9 @@ kotlin {
 
 
 dependencies {
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.2.2")                // https://plugins.gradle.org/plugin/com.github.spotbugs
+    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.4.8")                // https://plugins.gradle.org/plugin/com.github.spotbugs
     implementation("com.diffplug.spotless:spotless-plugin-gradle:7.2.1")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
     implementation("org.javamodularity:moduleplugin:2.0.0")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")                           // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin
-    implementation("com.gradle.publish:plugin-publish-plugin:1.3.1")                        // https://plugins.gradle.org/plugin/com.gradle.plugin-publish
+    implementation("com.gradle.publish:plugin-publish-plugin:2.1.1")                        // https://plugins.gradle.org/plugin/com.gradle.plugin-publish
 }

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstanceTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstanceTest.java
@@ -77,6 +77,7 @@ class ContainerInstanceTest {
 
     private static final DockerImageName IMAGE_NAME =
             DockerImageName.parse("ghcr.io/creek-service/creek-system-test-test-service:latest");
+
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     private static final Path CONTAINER_PATH = Path.of("/opt/container/path");
     private static final Path HOST_PATH = Path.of("/tmp/host/path");

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstanceTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstanceTest.java
@@ -38,10 +38,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.testing.NullPointerTester;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstanceTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstanceTest.java
@@ -80,6 +80,7 @@ class ContainerInstanceTest {
 
     @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     private static final Path CONTAINER_PATH = Path.of("/opt/container/path");
+
     private static final Path HOST_PATH = Path.of("/tmp/host/path");
 
     @Mock(answer = RETURNS_DEEP_STUBS, strictness = LENIENT)

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstanceTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstanceTest.java
@@ -41,6 +41,7 @@ import com.google.common.testing.NullPointerTester;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -76,6 +77,7 @@ class ContainerInstanceTest {
 
     private static final DockerImageName IMAGE_NAME =
             DockerImageName.parse("ghcr.io/creek-service/creek-system-test-test-service:latest");
+    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     private static final Path CONTAINER_PATH = Path.of("/opt/container/path");
     private static final Path HOST_PATH = Path.of("/tmp/host/path");
 

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstanceTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerInstanceTest.java
@@ -73,14 +73,12 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.ThrowingFunction;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
 class ContainerInstanceTest {
 
     private static final DockerImageName IMAGE_NAME =
             DockerImageName.parse("ghcr.io/creek-service/creek-system-test-test-service:latest");
-
-    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     private static final Path CONTAINER_PATH = Path.of("/opt/container/path");
-
     private static final Path HOST_PATH = Path.of("/tmp/host/path");
 
     @Mock(answer = RETURNS_DEEP_STUBS, strictness = LENIENT)

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -338,6 +339,7 @@ class PicoCliParserTest {
                 is(Optional.of(Map.of("NAME", "VALUE", "NAME2", "V2"))));
     }
 
+    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     @Test
     void shouldParseReadOnlyMount() {
         // Given:

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/result/ResultLogFormatterTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/result/ResultLogFormatterTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Optional;
 import org.creekservice.api.system.test.extension.test.model.TestCaseResult;
@@ -58,7 +57,6 @@ class ResultLogFormatterTest {
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private TestCaseResult testResult2;
 
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
     @BeforeEach
     void setUp() {
         doReturn(List.of(suiteResult0, suiteResult1)).when(result).results();

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/result/xml/XmlTestSuiteResultTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/result/xml/XmlTestSuiteResultTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -52,7 +51,6 @@ class XmlTestSuiteResultTest {
     @Mock private CreekTestSuite testSuite;
     private XmlTestSuiteResult xmlResult;
 
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
     @BeforeEach
     void setUp() {
         when(suiteResult.testSuite()).thenReturn(testSuite);


### PR DESCRIPTION
Aligns buildSrc plugin versions with the rest of the Creek estate:
- spotbugs-gradle-plugin → 6.4.8
- plugin-publish-plugin → 2.1.1 (where applicable)
- buildSrc JVM target → Java 17 (where applicable)
- Kotlin DSL syntax fix (where applicable)