### PR TITLE
fix: use @@ separator for --env/--debug-env to fix Windows comma parsing

### DIFF
--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/cli/PicoCliParser.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/cli/PicoCliParser.java
@@ -194,17 +194,17 @@ public final class PicoCliParser {
 
         @Option(
                 names = {"-de", "--debug-env"},
-                split = ",",
+                split = "@@",
                 description =
-                        "Comma seperated list of key=value environment variables to set on each"
+                        "@@-separated list of key=value environment variables to set on each"
                                 + " service being debugged.")
         private Map<String, String> debugEnv = Map.of();
 
         @Option(
                 names = {"-e", "--env"},
-                split = ",",
+                split = "@@",
                 description =
-                        "Comma seperated list of key=value environment variables to set on each"
+                        "@@-separated list of key=value environment variables to set on each"
                                 + " service-under-test.")
         private Map<String, String> env = Map.of();
 
@@ -362,14 +362,20 @@ public final class PicoCliParser {
                     : map.entrySet().stream()
                             .map(e -> e.getKey() + "=" + e.getValue())
                             .sorted()
-                            .collect(Collectors.joining(","));
+                            .collect(Collectors.joining("@@"));
         }
 
         private static String formatTransferables(final List<DirectoryInfo> transferables) {
             return transferables.isEmpty()
                     ? NOT_SET
                     : transferables.stream()
-                            .map(info -> info.hostPath() + "=" + info.containerPath())
+                            .map(
+                                    info ->
+                                            info.hostPath()
+                                                    + "="
+                                                    + info.containerPath()
+                                                            .toString()
+                                                            .replace('\\', '/'))
                             .collect(Collectors.joining(","));
         }
 

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
@@ -620,7 +620,7 @@ class PicoCliParserTest {
                                         + "--mount-writable="
                                         + mwS0
                                         + "="
-                                        + mwD0
+                                        + mwD0.toString().replace(File.separatorChar, '/')
                                         + ","
                                         + mwS1
                                         + "="

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
@@ -240,7 +240,7 @@ class PicoCliParserTest {
     @Test
     void shouldParseSingleMultipleEnvInSingleParam() {
         // Given:
-        final String[] args = minimalArgs("--env=NAME=VALUE,NAME2=V2");
+        final String[] args = minimalArgs("--env=NAME=VALUE@@NAME2=V2");
 
         // When:
         final Optional<ExecutorOptions> result = parse(args);
@@ -295,7 +295,7 @@ class PicoCliParserTest {
     @Test
     void shouldParseSingleMultipleDebugEnvInSingleParam() {
         // Given:
-        final String[] args = minimalArgs("--debug-env=NAME=VALUE,NAME2=V2", "--debug-service=a");
+        final String[] args = minimalArgs("--debug-env=NAME=VALUE@@NAME2=V2", "--debug-service=a");
 
         // When:
         final Optional<ExecutorOptions> result = parse(args);
@@ -576,7 +576,7 @@ class PicoCliParserTest {
                         "-ds=a,b",
                         "-dsi=a-0,b-1",
                         "-de=E=F",
-                        "-e=A=B,C=D",
+                        "-e=A=B@@C=D",
                         "--dir-copy-read-only=" + mrS0 + "=" + mrD0 + "," + mrS1 + "=" + mrD1,
                         "--dir-copy-read-write=" + mwS0 + "=" + mwD0 + "," + mwS1 + "=" + mwD1);
 
@@ -606,7 +606,7 @@ class PicoCliParserTest {
                                         + lineSeparator()
                                         + "--debug-env=E=F"
                                         + lineSeparator()
-                                        + "--env=A=B,C=D"
+                                        + "--env=A=B@@C=D"
                                         + lineSeparator()
                                         + "--mount-read-only="
                                         + mrS0


### PR DESCRIPTION
## Problem

On Windows, Java's ProcessBuilder/command-line parsing strips inner double-quotes from JVM arguments. When the executor uses `split=","` in picocli options for `--env` and `--debug-env`, the comma-separated JAVA_TOOL_OPTIONS values (e.g., jacoco agent args containing `append=true,dumponexit=true,...` or attachme agent args with `host:...,port:1234`) get split into separate map entries.

This causes test failures in the creek-system-test-gradle-plugin Windows CI build.

Additionally, on Windows, `Paths.get("/opt/creek/...")" normalises the path to use backslashes in the echo output, breaking container path assertions.

## Fix

- Change `split=","` to `split="@@"` for `--debug-env` and `--env` options  
- Update `formatMap()` to join with `@@`  
- Normalize container path separators to `/` in `formatTransferables()` echo output