### PR TITLE
fix: use semicolon separator for --env/--debug-env instead of @@

### DIFF
--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/cli/PicoCliParser.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/cli/PicoCliParser.java
@@ -194,17 +194,17 @@ public final class PicoCliParser {
 
         @Option(
                 names = {"-de", "--debug-env"},
-                split = "@@",
+                split = ";",
                 description =
-                        "@@-separated list of key=value environment variables to set on each"
+                        "Semicolon-separated list of key=value environment variables to set on each"
                                 + " service being debugged.")
         private Map<String, String> debugEnv = Map.of();
 
         @Option(
                 names = {"-e", "--env"},
-                split = "@@",
+                split = ";",
                 description =
-                        "@@-separated list of key=value environment variables to set on each"
+                        "Semicolon-separated list of key=value environment variables to set on each"
                                 + " service-under-test.")
         private Map<String, String> env = Map.of();
 
@@ -362,7 +362,7 @@ public final class PicoCliParser {
                     : map.entrySet().stream()
                             .map(e -> e.getKey() + "=" + e.getValue())
                             .sorted()
-                            .collect(Collectors.joining("@@"));
+                            .collect(Collectors.joining(";"));
         }
 
         private static String formatTransferables(final List<DirectoryInfo> transferables) {

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/cli/PicoCliParserTest.java
@@ -241,7 +241,7 @@ class PicoCliParserTest {
     @Test
     void shouldParseSingleMultipleEnvInSingleParam() {
         // Given:
-        final String[] args = minimalArgs("--env=NAME=VALUE@@NAME2=V2");
+        final String[] args = minimalArgs("--env=NAME=VALUE;NAME2=V2");
 
         // When:
         final Optional<ExecutorOptions> result = parse(args);
@@ -296,7 +296,7 @@ class PicoCliParserTest {
     @Test
     void shouldParseSingleMultipleDebugEnvInSingleParam() {
         // Given:
-        final String[] args = minimalArgs("--debug-env=NAME=VALUE@@NAME2=V2", "--debug-service=a");
+        final String[] args = minimalArgs("--debug-env=NAME=VALUE;NAME2=V2", "--debug-service=a");
 
         // When:
         final Optional<ExecutorOptions> result = parse(args);
@@ -578,7 +578,7 @@ class PicoCliParserTest {
                         "-ds=a,b",
                         "-dsi=a-0,b-1",
                         "-de=E=F",
-                        "-e=A=B@@C=D",
+                        "-e=A=B;C=D",
                         "--dir-copy-read-only=" + mrS0 + "=" + mrD0 + "," + mrS1 + "=" + mrD1,
                         "--dir-copy-read-write=" + mwS0 + "=" + mwD0 + "," + mwS1 + "=" + mwD1);
 
@@ -608,7 +608,7 @@ class PicoCliParserTest {
                                         + lineSeparator()
                                         + "--debug-env=E=F"
                                         + lineSeparator()
-                                        + "--env=A=B@@C=D"
+                                        + "--env=A=B;C=D"
                                         + lineSeparator()
                                         + "--mount-read-only="
                                         + mrS0


### PR DESCRIPTION
Replace the `@@` multi-value split separator with `;` (semicolon) for the `--env` and `--debug-env` picocli options and in the `formatMap()` echo output.

Semicolons are more conventional and readable than `@@`, and like `@@`, cannot appear in environment variable names (`[A-Za-z_][A-Za-z0-9_]*`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>