### PR TITLE
feat: support ${SERVICE_INSTANCE_NAME} placeholder in env vars

### DIFF
--- a/executor/src/main/java/org/creekservice/api/system/test/executor/ExecutorOptions.java
+++ b/executor/src/main/java/org/creekservice/api/system/test/executor/ExecutorOptions.java
@@ -97,6 +97,10 @@ public interface ExecutorOptions {
      * <p>For example, this can be used to set the {@code JAVA_TOOLS_OPTIONS} required to enable
      * coverage metrics capture.
      *
+     * <p>Environment variable values may contain the placeholder {@code ${SERVICE_INSTANCE_NAME}},
+     * which will be replaced with the name of the service instance before the variable is set on
+     * the container. This allows per-instance configuration.
+     *
      * @return map of environment variables to set on each service-under-test.
      */
     default Map<String, String> env() {

--- a/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerFactory.java
+++ b/executor/src/main/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerFactory.java
@@ -200,20 +200,21 @@ public final class ContainerFactory implements TestEnvironmentListener {
     }
 
     private Map<String, String> buildEnv(
-            final boolean serviceUnderTest, final Optional<Integer> serviceDebugPort) {
-        final Map<String, String> baseEnv = serviceUnderTest ? env : Map.of();
-        if (serviceDebugPort.isEmpty()) {
-            return baseEnv;
+            final String instanceName,
+            final boolean serviceUnderTest,
+            final Optional<Integer> serviceDebugPort) {
+        final Map<String, String> configured = new HashMap<>(serviceUnderTest ? env : Map.of());
+        if (serviceDebugPort.isPresent()) {
+            configured.putAll(serviceDebugInfo.env());
+            configured.computeIfPresent(
+                    "JAVA_TOOL_OPTIONS",
+                    (k, v) ->
+                            v.replaceAll(
+                                    "\\$\\{SERVICE_DEBUG_PORT}",
+                                    String.valueOf(serviceDebugPort.get())));
         }
 
-        final Map<String, String> configured = new HashMap<>(baseEnv);
-        configured.putAll(serviceDebugInfo.env());
-        configured.computeIfPresent(
-                "JAVA_TOOL_OPTIONS",
-                (k, v) ->
-                        v.replaceAll(
-                                "\\$\\{SERVICE_DEBUG_PORT}",
-                                String.valueOf(serviceDebugPort.get())));
+        configured.replaceAll((k, v) -> v.replace("${SERVICE_INSTANCE_NAME}", instanceName));
         return Map.copyOf(configured);
     }
 
@@ -222,7 +223,7 @@ public final class ContainerFactory implements TestEnvironmentListener {
             final GenericContainer<?> container,
             final boolean serviceUnderTest,
             final Optional<Integer> serviceDebugPort) {
-        final Map<String, String> env = buildEnv(serviceUnderTest, serviceDebugPort);
+        final Map<String, String> env = buildEnv(instanceName, serviceUnderTest, serviceDebugPort);
         if (!env.isEmpty()) {
             LOGGER.info("Setting container env. instance: " + instanceName + ", env : " + env);
             container.withEnv(env);

--- a/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerFactoryTest.java
+++ b/executor/src/test/java/org/creekservice/internal/system/test/executor/api/test/env/suite/service/ContainerFactoryTest.java
@@ -470,6 +470,90 @@ class ContainerFactoryTest {
 
     @ValueSource(booleans = {true, false})
     @ParameterizedTest
+    void shouldReplaceServiceInstanceNameInEnvVarsOfServicesUnderTest(final boolean debug) {
+        // Given:
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(),
+                        Map.of("JAVA_TOOL_OPTIONS", "destfile=/${SERVICE_INSTANCE_NAME}.exec"),
+                        regularFactory,
+                        debugFactory,
+                        networkSupplier);
+        when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(debug);
+
+        // When:
+        containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, true, () -> {});
+
+        // Then:
+        verify(container)
+                .withEnv(Map.of("JAVA_TOOL_OPTIONS", "destfile=/" + INSTANCE_NAME + ".exec"));
+    }
+
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest
+    void shouldReplaceServiceInstanceNameInAllEnvVars(final boolean debug) {
+        // Given:
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(),
+                        Map.of(
+                                "VAR_A", "a-${SERVICE_INSTANCE_NAME}",
+                                "VAR_B", "b-${SERVICE_INSTANCE_NAME}"),
+                        regularFactory,
+                        debugFactory,
+                        networkSupplier);
+        when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(debug);
+
+        // When:
+        containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, true, () -> {});
+
+        // Then:
+        verify(container)
+                .withEnv(
+                        Map.of(
+                                "VAR_A", "a-" + INSTANCE_NAME,
+                                "VAR_B", "b-" + INSTANCE_NAME));
+    }
+
+    @Test
+    void shouldReplaceServiceInstanceNameInDebugEnvVars() {
+        // Given:
+        when(serviceDebugInfo.env())
+                .thenReturn(Map.of("JAVA_TOOL_OPTIONS", "destfile=/${SERVICE_INSTANCE_NAME}.exec"));
+        when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(true);
+
+        // When:
+        containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, false, () -> {});
+
+        // Then:
+        verify(container)
+                .withEnv(Map.of("JAVA_TOOL_OPTIONS", "destfile=/" + INSTANCE_NAME + ".exec"));
+    }
+
+    @Test
+    void shouldNotReplaceServiceInstanceNameInEnvVarsOf3rdPartyServices() {
+        // Given:
+        containerFactory =
+                new ContainerFactory(
+                        serviceDebugInfo,
+                        List.of(),
+                        Map.of("JAVA_TOOL_OPTIONS", "destfile=/${SERVICE_INSTANCE_NAME}.exec"),
+                        regularFactory,
+                        debugFactory,
+                        networkSupplier);
+        when(serviceDebugInfo.shouldDebug(any(), any())).thenReturn(false);
+
+        // When:
+        containerFactory.create(IMAGE_NAME, INSTANCE_NAME, SERVICE_NAME, false, () -> {});
+
+        // Then: no env set at all (3rd party service with no debug env)
+        verify(container, never()).withEnv(any());
+    }
+
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest
     void shouldCopyDirectoriesIntoServicesUnderTest(final boolean debug) {
         // Given:
         containerFactory =


### PR DESCRIPTION
## What

Allow environment variable values to contain the placeholder `${SERVICE_INSTANCE_NAME}`, which is replaced with the service instance name before being set on the container.

## Why

This enables per-instance configuration when running multiple instances of the same service — for example, setting unique file paths or identifiers per instance.

## Changes

- `ExecutorOptions`: document the new placeholder in the `env()` Javadoc
- `ContainerFactory.buildEnv`: accept `instanceName`, apply debug env unconditionally when a debug port is present, then replace `${SERVICE_INSTANCE_NAME}` across all env values
- `ContainerFactoryTest`: add test cases covering all four scenarios (service-under-test / 3rd-party × debug on/off)